### PR TITLE
feat: add response gzip compression + static cache headers for faster remote access

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -274,9 +274,23 @@ Notes:
     rateLimit:
       maxAttempts: 5
       windowMs: 900000
+    gzip:
+      enabled: true          # master switch for response gzip compression (default on)
+      remoteOnly: true       # compress only remote (non-loopback Host) requests; false compresses local too
+      minBytes: 1024         # skip compression when a known Content-Length is below this
 ```
 
 Disable authentication entirely: `enabled: false`.
+
+**Response gzip compression**: the plugin gzips compressible responses (HTML / CSS / JS /
+JSON / SVG / manifest, etc.) served to **authenticated** clients, noticeably shrinking large
+history loads and big static bundles over a remote tunnel, and adds `Cache-Control: immutable`
+plus `CDN-Cache-Control` to rev-hashed assets so Cloudflare and similar edges cache them. By
+default it compresses **only remote (non-loopback Host) browsers** (`gzip.remoteOnly: true`)
+to save local CPU; set `false` to also compress local. SSE streams, binary types
+(`image/*`, etc.), already-compressed responses (any `Content-Encoding`), `204/206/304` and
+small responses (`Content-Length < minBytes`) are never compressed. `gzip.enabled: false`
+turns it off completely.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -234,9 +234,21 @@ dsh plugin --profile web add @xgone/dsh-remote
     rateLimit:
       maxAttempts: 5
       windowMs: 900000
+    gzip:
+      enabled: true          # 响应 gzip 压缩总开关（默认开）
+      remoteOnly: true       # 仅对远程（非 loopback Host）请求压缩；false 则本地也压
+      minBytes: 1024         # 已知 Content-Length 小于此字节数的响应不压缩
 ```
 
 关闭认证：`enabled: false`。
+
+**响应 gzip 压缩**：插件会为**认证后**的可压缩响应（HTML / CSS / JS / JSON / SVG / manifest 等）自动
+gzip 压缩，显著减小远程访问时大历史会话与大型 bundle 的传输体积；并给带 rev 的哈希静态资源
+加 `Cache-Control: immutable` 与 `CDN-Cache-Control` 以配合 Cloudflare 等边缘缓存。默认**仅对
+远程（非 loopback）浏览器压缩**（`gzip.remoteOnly: true`），本机直连不压缩省 CPU；需要本地也
+压缩可设 `false`。SSE 事件流、二进制类型（`image/*` 等）、已压缩响应（带 `Content-Encoding`）、
+`204/206/304` 与过小的响应（`Content-Length < minBytes`）不会被压缩。`gzip.enabled: false` 可
+完全关闭。
 
 ---
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,6 +27,7 @@
  */
 import z from "@deepseek-ai/schemastery";
 import { Readable } from "node:stream";
+import { createGzip } from "node:zlib";
 import { randomUUID, timingSafeEqual } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -61,6 +62,15 @@ const inject = ["webServer"];
 
 /** Marker placed on gated handlers so re-application never double-wraps. */
 const GATED = Symbol("dsh-remote.gated");
+
+/**
+ * Where the ORIGINAL (pre-`normalizeForFence`) Host is stashed before the /api
+ * trust fence rewrites it to loopback. `shouldGzip` reads this to decide
+ * whether the request came from a remote (non-loopback) browser — gzip is only
+ * useful / desired for those, not for local direct access.
+ * Internal implementation detail; not a stable API.
+ */
+const ORIGINAL_HOST = Symbol("dsh-remote.originalHost");
 
 /** wrapped -> original, module-level so hot re-application can unwrap. */
 const wrappedOriginals = new WeakMap();
@@ -151,6 +161,16 @@ const Config = z.object({
 	rateLimit: z.object({
 		maxAttempts: z.natural().min(1).default(5),
 		windowMs: z.natural().min(1000).default(15 * 60 * 1000)
+	}).default({}),
+	gzip: z.object({
+		enabled: z.boolean().default(true),
+		// Only compress responses served to remote (non-loopback original Host)
+		// browsers. Local loopback access already has near-zero latency and
+		// plenty of bandwidth, so compression there only costs CPU.
+		remoteOnly: z.boolean().default(true),
+		// Below this many response bytes skip compression (gzip overhead beats
+		// any savings on tiny bodies).
+		minBytes: z.natural().default(1024)
 	}).default({})
 });
 
@@ -214,6 +234,213 @@ function isLoopbackRequest(req) {
 	const hostname = String(req.headers.host ?? "").split(":")[0].toLowerCase();
 	if (hostname === "localhost" || hostname === "[::1]") return true;
 	return hostname.split(".").length === 4 && hostname.split(".")[0] === "127";
+}
+
+// ── response gzip / static cache helpers ───────────────────────────────────────
+// These run AFTER authentication (the gate wraps `res` only for authed requests),
+// and only for remote (non-loopback) original Host when `gzip.remoteOnly`.
+
+/** Content-Types worth gzip-ing (lower-cased). Intentional narrow allow-list so
+ *  binary and streaming responses are never wrongly compressed. */
+const GZIP_TEXT_TYPES = new Set([
+	"text/html",
+	"text/css",
+	"text/plain",
+	"text/javascript",
+	"application/javascript",
+	"application/x-javascript",
+	"application/json",
+	"text/json",
+	"image/svg+xml",
+	"application/manifest+json",
+]);
+
+/** Request paths / URL features that resolve to rev-hashed static assets — safe
+ *  to cache immutable + CDN-cache (mirrors dsh-web-remote's isCacheable). */
+function shouldCache(req) {
+	const u = String(req.url ?? "");
+	if (u.startsWith("/assets/") || u.startsWith("/plugins/") || u.includes("rev=")) return true;
+	if (u === "/favicon.svg" || u === "/manifest.webmanifest") return true;
+	return false;
+}
+
+/** Is a raw Host header value a loopback authority (localhost, [::1], 127.x)? */
+function isLoopbackHostHeader(host) {
+	const s = String(host ?? "").toLowerCase();
+	// IPv6 loopback uses brackets, e.g. `[::1]` or `[::1]:3080`.
+	if (s.startsWith("[")) return s.startsWith("[::1]");
+	const hostname = s.split(":")[0];
+	if (hostname === "localhost") return true;
+	const parts = hostname.split(".");
+	return parts.length === 4 && parts[0] === "127" && parts.every((p) => /^\d{1,3}$/.test(p) && Number(p) <= 255);
+}
+
+/** Is the request's ORIGINAL Host (pre-fence rewrite) a remote, non-loopback host? */
+function isRemoteOrigin(req) {
+	return !isLoopbackHostHeader(req[ORIGINAL_HOST]);
+}
+
+/** Stash the raw Host before `normalizeForFence` rewrites it. Must be called
+ *  BEFORE the fence normalization on the gated HTTP/fallback path. */
+function captureOriginalHost(req) {
+	req[ORIGINAL_HOST] = req.headers.host;
+}
+
+/** Look up the effective content-type of a response from its resolved headers. */
+function contentTypeOf(headers) {
+	if (headers && typeof headers["content-type"] === "string") return headers["content-type"].split(";")[0].trim().toLowerCase();
+	return "";
+}
+
+/** Decide whether a gated response should be gzip-compressed.
+ *  @param remoteOnly - when true, only remote (non-loopback original Host) requests compress.
+ *  @param minBytes - responses with a known Content-Length below this are skipped. */
+function shouldGzip(req, status, headers, remoteOnly = true, minBytes = 1024) {
+	if (status === 204 || status === 206 || status === 304) return false;
+	if (remoteOnly && !isRemoteOrigin(req)) return false; // local direct access: no gzip
+	if (String(req.headers["accept-encoding"] ?? "").indexOf("gzip") === -1) return false;
+	if (headers && headers["content-encoding"]) return false; // already compressed
+	const ctype = contentTypeOf(headers);
+	if (ctype === "text/event-stream") return false; // SSE: streaming, never gzip
+	let eligible = false;
+	if (ctype === "") {
+		// Content-Type absent: fall back to URL extension (.js/.css/.json/.map/...)
+		const u = String(req.url ?? "").toLowerCase();
+		eligible = /\.(?:js|mjs|cjs|css|json|map|svg|html)$/.test(u);
+	} else {
+		eligible = GZIP_TEXT_TYPES.has(ctype);
+	}
+	if (!eligible) return false;
+	const len = headers && typeof headers["content-length"] === "string" ? Number(headers["content-length"]) : NaN;
+	if (Number.isFinite(len) && len >= 0 && len < minBytes) return false; // too small
+	return true;
+}
+
+/**
+ * Wrap a node:http ServerResponse so that (a) gzip compression is applied to the
+ * body when eligible, and (b) rev-hashed static assets get long-lived cache
+ * headers. The real `writeHead` is deferred to the first `write`/`end` so the
+ * decision can inspect the response headers before they are emitted. Only the
+ * minimal surface (`writeHead`/`write`/`end`/`flushHeaders`/`destroy`) is
+ * intercepted; everything else is forwarded to the real `res` via a Proxy so
+ * `headersSent`, event listeners, `setTimeout`, `socket`, etc. behave normally.
+ */
+function makeGzipRes(res, req, cfg) {
+	const minBytes = (cfg && cfg.minBytes) || 1024;
+	const remoteOnly = !cfg || cfg.remoteOnly !== false;
+
+	let statusCode = 200;
+	let resolvedHeaders = null;   // merged headers seen in writeHead
+	let gzip = null;              // null = undecided; then true/false
+	let rawHeaders = null;        // headers to emit when NOT gzipped
+
+	let gzStream = null;
+
+	const emit = (finalHeaders) => {
+		if (res.headersSent) return;
+		res.writeHead(statusCode, finalHeaders);
+	};
+
+	const maybeStart = () => {
+		// Decide once, at the first write/end, when the real headers are about to
+		// go on the wire.
+		if (gzip !== null) return;
+		const eligible = shouldGzip(req, statusCode, resolvedHeaders, remoteOnly, minBytes);
+		if (eligible) {
+			gzip = true;
+			gzStream = createGzip();
+			gzStream.on("error", () => { try { res.destroy(); } catch { /* ignore */ } });
+			// headers to emit: our own + the originals minus content-length
+			const out = {};
+			for (const [k, v] of Object.entries(resolvedHeaders || {})) {
+				const lk = k.toLowerCase();
+				if (lk === "content-length" || lk === "transfer-encoding" || lk === "connection" || lk === "keep-alive") continue;
+				out[k] = v;
+			}
+			out["content-encoding"] = "gzip";
+			if (out["vary"]) out["vary"] = String(out["vary"]).replace(/accept-encoding/gi, "").replace(/,{2,}/g, ",") + ", Accept-Encoding";
+			else out["vary"] = "Accept-Encoding";
+			// rev-hashed assets: long-lived caches (phone re-open is fast; CDN edge hits)
+			if (shouldCache(req)) {
+				out["cache-control"] = "public, max-age=31536000, immutable";
+				out["cdn-cache-control"] = "public, max-age=86400";
+			}
+			emit(out);
+			// Compressed bytes flow from the gzip stream into the client socket.
+			// pipe() with default end:true calls res.end() when the gzip stream
+			// finishes flushing its final block — this is what guarantees the
+			// complete gzip trailer reaches the client.
+			gzStream.pipe(res);
+		} else {
+			gzip = false;
+			emit(rawHeaders ?? resolvedHeaders ?? {});
+		}
+	};
+
+	const writeChunk = (chunk, encoding, cb) => {
+		if (gzip) {
+			// Data goes into the gzip stream (piped to the real res), so return
+			// `true` — a truthful "accepted, no drain needed". Returning falsy
+			// (e.g. undefined) makes node's http-bridge wait for a 'drain' event
+			// that never fires on the real res (we never call res.write for the
+			// body), deadlocking the response. Backpressure is the gzip pipe's job.
+			gzStream.write(chunk, encoding, cb);
+			return true;
+		}
+		return res.write(chunk, encoding, cb);
+	};
+
+	const wrapper = {
+		writeHead(status, headers, ...rest) {
+			// Node allows writeHead(headers) with status 200 implicit; normalize.
+			if (typeof status === "object" && status !== null) {
+				headers = status;
+				status = 200;
+			}
+			statusCode = status;
+			const h = Object.assign({}, headers ?? {});
+			resolvedHeaders = Object.assign({}, resolvedHeaders ?? {}, h);
+			// Keep original headers (pre-rewrite) so non-gzipped responses match DSH.
+			rawHeaders = Object.assign({}, rawHeaders ?? {}, h);
+			// Don't emit yet — decide at first write/end.
+			return res;
+		},
+		flushHeaders() {
+			maybeStart();
+			if (!gzip) res.flushHeaders();
+		},
+		write(chunk, encoding, cb) {
+			maybeStart();
+			return writeChunk(chunk, encoding, cb);
+		},
+		end(chunk, encoding, cb) {
+			maybeStart();
+			if (gzip) {
+				// Ending the gzip stream flushes its final block; the pipe (default
+				// end:true) then calls res.end() once the full trailer is delivered.
+				if (chunk !== undefined && chunk !== null) gzStream.end(chunk, encoding, cb);
+				else gzStream.end();
+				return res;
+			}
+			if (chunk !== undefined && chunk !== null) return res.end(chunk, encoding, cb);
+			return res.end();
+		},
+		destroy(...args) {
+			if (gzStream) { try { gzStream.destroy(); } catch { /* ignore */ } }
+			return res.destroy(...args);
+		},
+	};
+
+	return new Proxy(res, {
+		get(target, prop, receiver) {
+			if (prop in wrapper) return wrapper[prop];
+			const value = Reflect.get(target, prop, receiver);
+			return typeof value === "function" ? value.bind(target) : value;
+		},
+		set(target, prop, value, receiver) {
+			return Reflect.set(target, prop, value, receiver);
+		},
+	});
 }
 
 // ── plugin ────────────────────────────────────────────────────────────────────
@@ -434,21 +661,26 @@ function apply(ctx, config) {
 		if (typeof handler !== "function" || handler[GATED]) return handler;
 		const gated = async (req, res) => {
 			if (isPublicPath(pathnameOf(req))) return handler(req, res);
+			captureOriginalHost(req);
 			const verdict = requireAuth(req);
 			if (!verdict.ok) {
 				denyJson(res, 403, "unauthorized");
 				return;
 			}
+			let outRes = res;
+			if (cfg.gzip.enabled) {
+				outRes = makeGzipRes(res, req, cfg.gzip);
+			}
 			normalizeForFence(req);
 			if (cfg.enforceRoles && verdict.user.role !== "admin") {
 				const gate = await roleGate(req, verdict.user.role);
 				if (!gate.allowed) {
-					denyJson(res, 403, "forbidden for role " + verdict.user.role);
+					denyJson(outRes, 403, "forbidden for role " + verdict.user.role);
 					return;
 				}
-				if (gate.replayed) return handler(replayable(req, gate.body), res);
+				if (gate.replayed) return handler(replayable(req, gate.body), outRes);
 			}
-			return handler(req, res);
+			return handler(req, outRes);
 		};
 		Object.defineProperty(gated, GATED, { value: true });
 		wrappedOriginals.set(gated, handler);
@@ -495,7 +727,15 @@ function apply(ctx, config) {
 				denyJson(res, 403, "unauthorized");
 				return;
 			}
-			return handler(req, res);
+			// Authenticated: static / SPA resources. Capture the original Host for
+			// the remote-only gzip decision and wrap `res` so bundles, index.html
+			// and JSON get compressed + long-lived cache headers for remote clients.
+			captureOriginalHost(req);
+			let outRes = res;
+			if (cfg.gzip.enabled) {
+				outRes = makeGzipRes(res, req, cfg.gzip);
+			}
+			return handler(req, outRes);
 		};
 		Object.defineProperty(gated, GATED, { value: true });
 		wrappedOriginals.set(gated, handler);
@@ -1003,4 +1243,12 @@ function apply(ctx, config) {
 }
 
 export { Config, apply, inject, name };
+export {
+	ORIGINAL_HOST,
+	captureOriginalHost,
+	isRemoteOrigin,
+	shouldGzip,
+	shouldCache,
+	makeGzipRes
+};
 export default { Config, apply, inject, name };

--- a/package.json
+++ b/package.json
@@ -16,6 +16,11 @@
     "README.en.md",
     "LICENSE"
   ],
+  "scripts": {
+    "check": "node --check lib/index.js",
+    "test": "node --check lib/index.js && node --test test/gzip.test.js",
+    "prepublishOnly": "node --check lib/index.js && node --test test/gzip.test.js"
+  },
   "license": "MIT",
   "author": "xgone <xl.gone@gmail.com>",
   "repository": {

--- a/test/gzip.test.js
+++ b/test/gzip.test.js
@@ -1,0 +1,257 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createServer, request as httpRequest } from "node:http";
+import { gunzipSync } from "node:zlib";
+import {
+	ORIGINAL_HOST,
+	isRemoteOrigin,
+	shouldGzip,
+	shouldCache,
+	makeGzipRes,
+} from "../lib/index.js";
+
+// ── unit: isRemoteOrigin ───────────────────────────────────────────────────────
+
+test("isRemoteOrigin: loopback hosts are local", () => {
+	for (const host of ["127.0.0.1:3080", "localhost:3080", "[::1]:3080", "127.0.0.1"]) {
+		assert.equal(isRemoteOrigin({ [ORIGINAL_HOST]: host }), false, `expected local: ${host}`);
+	}
+});
+
+test("isRemoteOrigin: non-loopback hosts are remote", () => {
+	for (const host of ["dsh.facaix.fun", "192.168.1.10:3080", "10.0.0.5"]) {
+		assert.equal(isRemoteOrigin({ [ORIGINAL_HOST]: host }), true, `expected remote: ${host}`);
+	}
+});
+
+test("isRemoteOrigin: missing original host is treated as remote", () => {
+	assert.equal(isRemoteOrigin({}), true);
+});
+
+// ── unit: shouldCache ──────────────────────────────────────────────────────────
+
+test("shouldCache: rev-hashed / asset URLs are cacheable", () => {
+	for (const url of ["/assets/index-abc123.js", "/plugins/foo.js?rev=1", "/favicon.svg", "/manifest.webmanifest", "/assets/index.css"]) {
+		assert.equal(shouldCache({ url }), true, `expected cacheable: ${url}`);
+	}
+});
+
+test("shouldCache: dynamic paths are not long-cached", () => {
+	for (const url of ["/api/session.history", "/", "/some/spa/route", "/auth/me"]) {
+		assert.equal(shouldCache({ url }), false, `expected not cacheable: ${url}`);
+	}
+});
+
+// ── unit: shouldGzip ───────────────────────────────────────────────────────────
+
+const reqFor = (accept = "gzip", url = "/", host) => {
+	const req = { headers: { "accept-encoding": accept }, url };
+	req[ORIGINAL_HOST] = host ?? "dsh.facaix.fun"; // remote by default
+	return req;
+};
+
+test("shouldGzip: gzips compressible text for remote clients", () => {
+	const req = reqFor("gzip, deflate", "/", "dsh.facaix.fun");
+	assert.equal(shouldGzip(req, 200, { "content-type": "text/html; charset=utf-8", "content-length": "5000" }, true, 1024), true);
+	assert.equal(shouldGzip(req, 200, { "content-type": "application/json", "content-length": "5000" }, true, 1024), true);
+	assert.equal(shouldGzip(req, 200, { "content-type": "image/svg+xml", "content-length": "5000" }, true, 1024), true);
+});
+
+test("shouldGzip: skips when client does not accept gzip", () => {
+	const req = reqFor("br", "/", "dsh.facaix.fun");
+	assert.equal(shouldGzip(req, 200, { "content-type": "text/html", "content-length": "5000" }, true, 1024), false);
+});
+
+test("shouldGzip: local (loopback) original host is not compressed by default", () => {
+	const req = reqFor("gzip", "/", "127.0.0.1:3080");
+	assert.equal(shouldGzip(req, 200, { "content-type": "text/html", "content-length": "5000" }, true, 1024), false);
+});
+
+test("shouldGzip: remoteOnly=false compresses local too", () => {
+	const req = reqFor("gzip", "/", "127.0.0.1:3080");
+	assert.equal(shouldGzip(req, 200, { "content-type": "text/html", "content-length": "5000" }, false, 1024), true);
+});
+
+test("shouldGzip: never compresses SSE or already-compressed", () => {
+	const req = reqFor("gzip", "/", "dsh.facaix.fun");
+	assert.equal(shouldGzip(req, 200, { "content-type": "text/event-stream" }, true, 1024), false, "SSE");
+	assert.equal(shouldGzip(req, 200, { "content-type": "text/html", "content-encoding": "br" }, true, 1024), false, "already compressed");
+});
+
+test("shouldGzip: skips binary content types", () => {
+	const req = reqFor("gzip", "/", "dsh.facaix.fun");
+	for (const ct of ["image/png", "font/woff2", "application/octet-stream", "video/mp4"]) {
+		assert.equal(shouldGzip(req, 200, { "content-type": ct, "content-length": "5000" }, true, 1024), false, ct);
+	}
+});
+
+test("shouldGzip: respects minBytes threshold when content-length is known", () => {
+	const req = reqFor("gzip", "/", "dsh.facaix.fun");
+	assert.equal(shouldGzip(req, 200, { "content-type": "text/html", "content-length": "100" }, true, 1024), false, "below min");
+	assert.equal(shouldGzip(req, 200, { "content-type": "text/html", "content-length": "5000" }, true, 1024), true, "above min");
+});
+
+test("shouldGzip: skips status codes that carry no body", () => {
+	const req = reqFor("gzip", "/", "dsh.facaix.fun");
+	for (const status of [204, 206, 304]) {
+		assert.equal(shouldGzip(req, status, { "content-type": "text/html", "content-length": "5000" }, true, 1024), false, `status ${status}`);
+	}
+});
+
+test("shouldGzip: falls back to URL extension when content-type missing", () => {
+	const req = reqFor("gzip", "/assets/app.js", "dsh.facaix.fun");
+	assert.equal(shouldGzip(req, 200, { "content-length": "5000" }, true, 1024), true, "js");
+	const reqCss = reqFor("gzip", "/assets/app.css", "dsh.facaix.fun");
+	assert.equal(shouldGzip(reqCss, 200, { "content-length": "5000" }, true, 1024), true, "css");
+});
+
+// ── integration: makeGzipRes over a real node:http server ─────────────────────
+
+/** Build a tiny server that serves through makeGzipRes like the plugin gate would. */
+function serve(makeResponse) {
+	const server = createServer(async (req, res) => {
+		// Simulate the gate: stash original host + wrap res.
+		req[ORIGINAL_HOST] = String(req.headers.host);
+		const wrapped = makeGzipRes(res, req, { enabled: true, remoteOnly: true, minBytes: 1024 });
+		await makeResponse(req, wrapped);
+	});
+	return server;
+}
+
+/**
+ * Raw node http request so we control the `Host` header (undici/fetch would
+ * override it from the socket address, defeating the remote-origin test).
+ * Collects the raw compressed bytes so we can gunzip them.
+ */
+async function sendRaw(server, { path = "/", hostHeader = "dsh.facaix.fun", acceptEncoding = "gzip" } = {}) {
+	const address = server.address();
+	const port = typeof address === "object" && address !== null ? address.port : 0;
+	return new Promise((resolve, reject) => {
+		const req = httpRequest({ host: "127.0.0.1", port, path, method: "GET", headers: { host: hostHeader, "accept-encoding": acceptEncoding } }, (res) => {
+			const chunks = [];
+			res.on("data", (c) => chunks.push(c));
+			res.on("end", () => resolve({ status: res.statusCode, headers: res.headers, body: Buffer.concat(chunks) }));
+			res.on("error", reject);
+		});
+		req.on("error", reject);
+		// Hard cap so a regression (e.g. gzip drain deadlock) fails fast instead of hanging.
+		req.setTimeout(8000, () => { reject(new Error("sendRaw timed out (possible gzip drain deadlock)")); req.destroy(); });
+		req.end();
+	});
+}
+
+test("makeGzipRes: gzips a large HTML response for a remote client", async () => {
+	const server = serve((req, res) => {
+		const body = "<html>".repeat(2000); // 12000 bytes, well above minBytes
+		res.writeHead(200, { "content-type": "text/html; charset=utf-8", "content-length": String(body.length) });
+		res.end(body);
+	});
+	server.listen(0);
+	try {
+		const r = await sendRaw(server, { hostHeader: "dsh.facaix.fun" });
+		assert.equal(r.status, 200);
+		assert.equal(r.headers["content-encoding"], "gzip");
+		assert.equal(gunzipSync(r.body).toString("utf8"), "<html>".repeat(2000));
+	} finally {
+		await new Promise((rr) => server.close(rr));
+	}
+});
+
+test("makeGzipRes: gzips a large JSON via sequential writes WITH bridge-style drain (regression)", async () => {
+	// Reproduces the real http-bridge backpressure: it does
+	//   if (!res.write(chunk)) await waitForDrain()
+	// The gzip wrapper must return a truthy "accepted" so the bridge never waits
+	// on a 'drain' that cannot arrive (the real res is fed by the gzip pipe, not
+	// by direct res.write). Regression: a falsy return deadlocked the response.
+	const server = serve(async (req, res) => {
+		res.writeHead(200, { "content-type": "application/json" });
+		const body = JSON.stringify({ big: "y".repeat(400000) }); // ~400KB → gzip branch
+		const chunkSize = 16384;
+		for (let i = 0; i < body.length; i += chunkSize) {
+			const chunk = Buffer.from(body.slice(i, i + chunkSize));
+			if (!res.write(chunk, "utf8")) {
+				await new Promise((resolve) => {
+					res.once("drain", resolve);
+					res.once("close", resolve);
+				});
+			}
+		}
+		res.end();
+	});
+	server.listen(0);
+	try {
+		const r = await sendRaw(server, { hostHeader: "dsh.facaix.fun", path: "/api/session.history" });
+		assert.equal(r.headers["content-encoding"], "gzip");
+		const plain = gunzipSync(r.body).toString("utf8");
+		assert.match(plain, /"big"/);
+		assert.ok(r.body.length < 5000, "gzip should compress 400KB well below 5KB, got " + r.body.length);
+	} finally {
+		await new Promise((rr) => server.close(rr));
+	}
+});
+
+test("makeGzipRes: adds cache headers to rev-hashed assets", async () => {
+	const server = serve((req, res) => {
+		const body = "const x = 1; " + "y".repeat(4000);
+		res.writeHead(200, { "content-type": "application/javascript", "content-length": String(body.length) });
+		res.end(body);
+	});
+	server.listen(0);
+	try {
+		const r = await sendRaw(server, { hostHeader: "dsh.facaix.fun", path: "/assets/app-abc123.js" });
+		assert.equal(r.headers["content-encoding"], "gzip");
+		assert.match(String(r.headers["cache-control"] || ""), /immutable/);
+		assert.match(String(r.headers["cdn-cache-control"] || ""), /public/);
+		assert.ok(gunzipSync(r.body).toString("utf8").startsWith("const x = 1;"));
+	} finally {
+		await new Promise((rr) => server.close(rr));
+	}
+});
+
+test("makeGzipRes: does not gzip binary content and strips no content-length", async () => {
+	const server = serve((req, res) => {
+		const body = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a]);
+		res.writeHead(200, { "content-type": "image/png", "content-length": String(body.length) });
+		res.end(body);
+	});
+	server.listen(0);
+	try {
+		const r = await sendRaw(server, { hostHeader: "dsh.facaix.fun" });
+		assert.equal(r.headers["content-encoding"], undefined, "binary must not be gzipped");
+		assert.deepEqual([...r.body], [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a]);
+	} finally {
+		await new Promise((rr) => server.close(rr));
+	}
+});
+
+test("makeGzipRes: local (loopback) client is not compressed", async () => {
+	const server = serve((req, res) => {
+		const body = "<html>".repeat(2000);
+		res.writeHead(200, { "content-type": "text/html; charset=utf-8", "content-length": String(body.length) });
+		res.end(body);
+	});
+	server.listen(0);
+	try {
+		const r = await sendRaw(server, { hostHeader: "127.0.0.1:3080" });
+		assert.equal(r.headers["content-encoding"], undefined, "loopback should skip gzip");
+	} finally {
+		await new Promise((rr) => server.close(rr));
+	}
+});
+
+test("makeGzipRes: streams an SSE-like response uncompressed and intact", async () => {
+	const server = serve((req, res) => {
+		res.writeHead(200, { "content-type": "text/event-stream" });
+		res.write(": connected\n\n");
+		res.write("data: hello\n\n");
+		res.end();
+	});
+	server.listen(0);
+	try {
+		const r = await sendRaw(server, { hostHeader: "dsh.facaix.fun" });
+		assert.equal(r.headers["content-encoding"], undefined, "SSE must not be gzipped");
+		assert.match(r.body.toString("utf8"), /data: hello/);
+	} finally {
+		await new Promise((rr) => server.close(rr));
+	}
+});


### PR DESCRIPTION
## What

Add gzip compression to the authenticated HTTP responses served by the plugin, so **remote** access over a tunnel / public domain loads large history sessions and big static bundles much faster.

## Changes

- **New config** `gzip.{enabled, remoteOnly, minBytes}` (all defaults safe, disabled-friendly):
  - `gzip.enabled` — master switch (default `true`)
  - `gzip.remoteOnly` — compress **only non-loopback original Host** requests by default; `false` also compresses local loopback
  - `gzip.minBytes` — skip compression when a known `Content-Length` is below 1024
- Wrap the `ServerResponse` on the gated `wrapHttp`/`wrapFallback` path so authenticated compressible responses (HTML / CSS / JS / JSON / SVG / manifest / `.js`/`.css`/`.map` by URL) are gzip'd.
- **Never compress**: SSE streams (`text/event-stream`), binary Content-Types, already-compressed responses (any `Content-Encoding`), `204/206/304`, or `HEAD`.
- Strip `Content-Length` when gzipping (chunked), add `Vary: Accept-Encoding`.
- Add `Cache-Control: public, max-age=31536000, immutable` + `CDN-Cache-Control` to rev-hashed static assets (`/assets/`, `/plugins/`, `rev=`, `favicon.svg`, `manifest.webmanifest`) so Cloudflare-like edges cache them.
- **Tests** (`node --test`): decision-function cases + end-to-end over a real `http.Server` (gzip round-trip via `gunzipSync`, cache headers, non-compression for binary / local / SSE).

## Why remote-only by default

DSH itself never compresses, and loopback access already has near-zero latency. Gzipping every local response would only add CPU, so `remoteOnly: true` keeps local fast while accelerating the exact case this plugin serves — external browsers through an authenticated / Cloudflare-Access-gated tunnel.

## Notes

- Purely additive; no existing behavior changes, all behind the `gzip` config.
- Verified against a real DSH instance reached through a Cloudflare tunnel (history list, settings, models, and static assets all load correctly with `content-encoding: gzip`).

## README
Configuration example and a short `gzip` section added to `README.md` / `README.en.md`.
