### PR TITLE
移动端回车换行不发送

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -266,6 +266,49 @@ window.__ModuleLoader__.load({
 			}
 		}
 
+		// ── mobile Enter → newline (not send) ─────────────────────────────────────
+		// On phones/tablets the on-screen keyboard's return key maps to Enter,
+		// so tapping it in the chat composer sends the draft instantly instead
+		// of inserting a newline — easy to fire accidentally and hard to undo.
+		// On a coarse-pointer (touch) device, turn plain Enter in the composer
+		// into a newline: the composer still sends via its send button (and via
+		// any modifier+Enter, which a hardware keyboard attached to the same
+		// coarse-pointer device can still use). Detected once and cached.
+		let mobileEnterInstalled = false;
+		function installMobileEnterNewline() {
+			if (mobileEnterInstalled) return;
+			mobileEnterInstalled = true;
+			try {
+				const media = window.matchMedia;
+				if (typeof media !== "function") return;
+				// Coarse pointer = the primary input is touch (phones/tablets).
+				// Desktop touchscreens are hybrids (a keyboard is present) where
+				// Enter-send stays ergonomic, so additionally require a
+				// phone/tablet-sized viewport to keep those on Enter-send.
+				const isCoarse = media("(pointer: coarse)").matches;
+				const isPhoneOrTablet = media("(max-width: 1024px)").matches;
+				if (!isCoarse || !isPhoneOrTablet) return;
+				document.addEventListener("keydown", (event) => {
+					// Only plain Enter in the chat composer — modifiers (Shift /
+					// Ctrl / Meta / Alt) keep their existing meanings, and the
+					// composer's own Enter (send / menu-pick) is what we replace.
+					if (event.key !== "Enter") return;
+					if (event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) return;
+					const target = event.target;
+					if (!(target instanceof HTMLTextAreaElement)) return;
+					// The chat composer's textarea lives inside [data-composer-card];
+					// other textareas (login, settings, user-questions) keep Enter-send.
+					if (target.closest("[data-composer-card]") === null) return;
+					// Stop the event before it reaches React's delegated listener
+					// (which would run onKeyDown → send), but do NOT preventDefault:
+					// the textarea's own default action inserts the newline.
+					event.stopImmediatePropagation();
+				}, true);
+			} catch (error) {
+				// MatchMedia / listener failure — leave DSH's native behavior.
+			}
+		}
+
 		// ── transport ─────────────────────────────────────────────────────────────
 		async function fetchJson(path, body) {
 			let res;
@@ -873,6 +916,12 @@ window.__ModuleLoader__.load({
 		const inject = ["slots", "locale"];
 
 		function apply(ctx) {
+			// On coarse-pointer (touch) devices, make plain Enter in the chat
+			// composer insert a newline instead of sending — see
+			// installMobileEnterNewline. Independent of remote/loopback and of
+			// auth state, so it runs for every mobile client.
+			installMobileEnterNewline();
+
 			// Register our zh/en dictionaries with the framework locale service
 			// and bind a live translator — the app-level language preference
 			// (including switches made at runtime) drives every t() call.


### PR DESCRIPTION
手机/平板上，输入框的回车会直接发送指令。改为仅移动端（触屏+手机/平板视口）普通回车换行、不发送；发送按钮和 Shift/Ctrl/Cmd+回车不受影响，桌面端行为不变。