### PR TITLE
fix(alpha.3): native browser-auth pairing, fallback Host normalization, and remote settings RPC

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1476,15 +1476,17 @@ window.__ModuleLoader__.load({
 					const active = ctx.locale.getSnapshot().active;
 					if (active === lastPersisted) return;
 					lastPersisted = active;
-					settingsRpc("settings.mutate", {
-						ns: "locale",
-						ops: [{ op: "set", path: ["preference"], value: active }]
+					settingsRpc("settings/mutate", {
+						args: {
+							ns: "locale",
+							ops: [{ op: "set", path: ["preference"], value: active }]
+						}
 					});
 				}), "dsh-remote: remote locale persistence");
 				// Boot re-adoption: the memory-mode scope never loads the host
 				// value, so fetch it ourselves and apply it. Harmless no-op when
 				// the active locale already matches.
-				settingsRpc("settings.describe", {}).then((result) => {
+				settingsRpc("settings/describe", { args: {} }).then((result) => {
 					const preference = result?.value?.namespaces
 						?.find((entry) => entry.ns === "locale")?.value?.preference;
 					if ((preference === "zh" || preference === "en") && preference !== ctx.locale.getSnapshot().active) {
@@ -1514,7 +1516,7 @@ window.__ModuleLoader__.load({
 				// coordinator skips the step — no popup, no DSH internals rewritten,
 				// no persistence flipped. Left as-is for first-time remote users
 				// (no ack yet) per scope decision.
-				settingsRpc("settings.describe", {}).then((result) => {
+				settingsRpc("settings/describe", { args: {} }).then((result) => {
 					const ack = result?.value?.namespaces
 						?.find((entry) => entry.ns === "ui-onboarding")?.value?.welcomeNoticeVersion;
 					if (typeof ack !== "string" || ack.length === 0) return;
@@ -1545,7 +1547,7 @@ window.__ModuleLoader__.load({
 				// is reached through the official ctx.settingsScope.describe() service).
 				// No DSH methods rewritten, no persistence flipped; a drifted mirror
 				// shape (version drift) degrades to the status quo ante.
-				settingsRpc("settings.describe", {}).then((result) => {
+				settingsRpc("settings/describe", { args: {} }).then((result) => {
 					const view = result?.value;
 					if (!view?.namespaces) return;
 					try {

--- a/lib/index.js
+++ b/lib/index.js
@@ -823,6 +823,20 @@ function apply(ctx, config) {
 	const wrapFallback = (handler) => {
 		if (typeof handler !== "function" || handler[GATED]) return handler;
 		const gated = async (req, res) => {
+			// Let the host launch-token pairing through the gate so the native
+			// browser-auth cookie can be minted on the first visit. Without this
+			// the login page is rendered first, the token is dropped, and the
+			// native auth cookie is never issued.
+			if (req.method === "GET") {
+				try {
+					const _u = new URL(req.url ?? "/", "http://dsh.invalid");
+					if (_u.pathname === "/" && _u.searchParams.has("token")) {
+						captureOriginalHost(req);
+						normalizeForFence(req);
+						return handler(req, res);
+					}
+				} catch {}
+			}
 			if (!requireAuth(req).ok) {
 				if (req.method === "GET" || req.method === "HEAD") {
 					const pathname = pathnameOf(req);
@@ -849,6 +863,7 @@ function apply(ctx, config) {
 			// the remote-only gzip decision and wrap `res` so bundles, index.html
 			// and JSON get compressed + long-lived cache headers for remote clients.
 			captureOriginalHost(req);
+			normalizeForFence(req);
 			let outRes = res;
 			if (cfg.gzip.enabled) {
 				outRes = makeGzipRes(res, req, cfg.gzip);


### PR DESCRIPTION
## Problem

On recent DSH builds two independent gaps break the plugin behind a reverse proxy on a public authority:

**1. Native browser-auth pairing is unreachable (`dsh web authentication required`)**

The connection plugin enforces a native browser-auth layer: every request must carry a `dsh-auth` cookie, minted by `authorizeIndex` when the browser first visits `/?token=<launch token>`. Two things break:

- `wrapFallback` intercepts `/?token=` before the native handler: an unauthenticated visitor gets the plugin login page, the token is never consumed, and the native cookie is never minted. After logging in through the plugin the token is gone, so the native auth layer keeps rejecting every request.
- The authenticated fallback branch hands requests to the connection plugin with the original public `Host`/`Origin`. The connection plugin's Host/Origin fence only accepts loopback (or explicitly configured `trustedHosts`), so every authenticated request is still rejected.

**2. Remote settings are dead (`settings are unavailable in this browser`)**

The settings describe mirror runs in memory mode for non-loopback browsers and never loads the host document, so the Models page reports `settings are unavailable in this browser`. The plugin re-hydrates the mirror through the official settings RPC — but it calls the old `settings.describe` / `settings.mutate` endpoint names, which 404 on newer DSH builds (renamed to `settings/describe` / `settings/mutate` with a single `args` argument field). The re-hydration silently no-ops.

## Fix

- `wrapFallback` now passes `GET /?token=` requests straight through to the wrapped handler (after `captureOriginalHost` + `normalizeForFence`) so `authorizeIndex` can mint the native cookie on the first visit.
- The authenticated fallback branch calls `normalizeForFence(req)`, matching what `wrapHttp` and `wrapUpgrade` already do.
- All four `settingsRpc` call sites (3× describe, 1× mutate) switch to the slash-namespace endpoints and the `{ args }` envelope shape.

## Verification

Behind a reverse proxy on a public authority (no `--trusted-host`, `trustProxy: true`):

1. `GET /?token=<launch token>` → `303` + `Set-Cookie: dsh-auth-…` (native cookie minted, no login page swallowed)
2. `POST /auth/login` → `200`, `dsh_session` issued
3. `GET /` with both cookies → `200` full SPA (previously `401 dsh web authentication required`)
4. `GET /api/remote.mux` (WebSocket upgrade) → `101`
5. `POST /api/settings/describe` → `200` with writable document, Models page loads and saves
