### PR TITLE
fix: mint dsh-auth cookies for dsh ≥ 0.1.2-alpha, adapt RPC wire shapes across generations (issue #10)

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -433,7 +433,13 @@ This plugin adapts (on by default, zero configuration):
   the next request without re-login;
 - **Old-dsh compatibility**: when the `client-connection/browser-session` credential record is
   absent (or the runtime has no `credentials` service), minting stays off and behavior is
-  identical to 0.3.0.
+  identical to 0.3.0;
+- **Browser-half RPC shape adaptation**: alpha renamed RPC endpoints to `namespace/method`
+  (slash) with a single `args` envelope field (`settings.describe` → `settings/describe`). The
+  client tries the new shape first, falls back to the dotted spelling on 404, and pins whichever
+  worked for the page — one bundle serves both rc and alpha; the host-half role gate likewise
+  normalizes slash method names before matching the dotted deny lists, so non-admin limits hold
+  on both generations.
 
 Configuration (rarely needed):
 

--- a/README.en.md
+++ b/README.en.md
@@ -218,6 +218,7 @@ kept (delete that file manually if you want a complete reset).
 | Settings → Plugins config page is blank over remote access | Built-in fix since v0.1.5: DSH switches every settings scope to memory mode for remote browsers (reads and writes are dropped client-side); the plugin unpins the scope queue at startup and triggers a full refresh, so the config cards are readable and writable remotely. The raw settings.yaml document editor intentionally stays loopback-only |
 | "Internal Testing Notice" re-pops on every remote refresh | Built-in fix since v0.1.6 (for users who already acknowledged): DSH's welcome-notice acknowledgement (`WelcomeNoticeStore`) runs in memory mode for remote browsers, so the persisted ack is never read; the plugin reads `ui-onboarding.welcomeNoticeVersion` through the official settings.describe RPC and, when one exists, sets the live store's `acknowledged` flag via the official `store.update` API — WelcomeNotice then auto-finishes and the notice stops re-popping. Uses only official slots/store/RPC; no DSH internals rewritten, no persistence flipped. First-time remote users (no ack yet) keep the original behavior |
 | Opening Settings → Models remotely fails with "Failed to load provider catalog: settings are unavailable in this browser" | Built-in fix since v0.2.6: the upgraded DSH routes every settings read through a shared `SettingsDescribeMirror` that is constructed in memory mode for remote browsers (view always undefined), so the Models page rejects. The plugin reads the settings document through the official settings.describe RPC, reaches the mirror through the official `ctx.settingsScope.describe()` service, and folds the document in through the official `store.set` API — the provider catalog loads normally remotely. Uses only official RPC/service/store APIs; no DSH methods rewritten, no persistence flipped |
+| After upgrading to dsh 0.1.2-alpha+, remote login succeeds but every `/api` call returns 401 (index.html may 401 too) | Built-in fix since v0.3.1 (issue #10): the new dsh `client-connection` additionally requires a persistent signed `dsh-auth-*` cookie bound to the request Host, which a remote browser can never obtain or mint; the plugin now mints and sets it at login with the exact core algorithm (one bound to the normalized loopback authority, one to the original public Host) and self-heals at the gate — **upgrade the plugin and sign in once more**; sessions created before the upgrade repair themselves on the next request |
 
 ### 2.6 Headless / Linux server install (no local browser)
 
@@ -287,6 +288,9 @@ Notes:
     files:
       enabled: true          # master switch for remote file display via /auth/file (default on)
       maxListing: 500        # max entries rendered per directory listing page
+    browserAuth:
+      enabled: true          # mint dsh-auth-* cookies on dsh >= 0.1.2-alpha (default on, see 4.3.1)
+      cookieTtlSeconds: 0    # 0 = follow session.ttlSeconds; capped by client-connection.cookieMaxAgeDays
 ```
 
 > **Windows note**: the directories readable by default are the DSH home dir and the dsh
@@ -407,6 +411,43 @@ loopback. After authentication the plugin normalizes the request's `Host`/`Origi
 `127.0.0.1:<port>` (preserving the original scheme) before handing it down — the fence sees
 loopback and privileged methods work for external browsers. Unauthenticated requests are still
 403'd by the gate, so the fence's DNS-rebinding semantics are no longer needed behind the cookie.
+
+### 4.3.1 New-dsh adaptation: minting `dsh-auth-*` session cookies (>= 0.1.2-alpha, issue #10)
+
+Since dsh `0.1.2-alpha`, `client-connection` additionally requires a persistent signed cookie
+**bound to the request Host** (`dsh-auth-<sha256(Host)>`, HMAC-SHA256, keyed by the
+`client-connection/browser-session` record in `$DSH_HOME/.credentials.yaml`) on `/api`, the
+stream WebSocket (`/api/remote.mux`) and index.html alike. That cookie is only minted by dsh's
+own `?token=<launch token>` exchange, which a remote browser can never reach — and it can never
+hold a cookie bound to `127.0.0.1:<port>` — so after login every `/api` call returned 401.
+
+This plugin adapts (on by default, zero configuration):
+
+- **On login / MFA / bootstrap success** it reads client-connection's persisted signing secret
+  and mints two `dsh-auth-*` cookies with the exact core algorithm: one bound to the
+  **normalized loopback authority** (used by `/api` and the stream WebSocket), one bound to the
+  **original public Host** (used by the index/static fallback path);
+- **Self-heal**: every gated request verifies that a live cookie for the relevant authority is
+  present (including core-minted ones) and appends a fresh mint onto the current response when
+  not — sessions created before this fix, or whose cookies were evicted, repair themselves on
+  the next request without re-login;
+- **Old-dsh compatibility**: when the `client-connection/browser-session` credential record is
+  absent (or the runtime has no `credentials` service), minting stays off and behavior is
+  identical to 0.3.0.
+
+Configuration (rarely needed):
+
+```yaml
+browserAuth:
+  enabled: true          # minting master switch
+  cookieTtlSeconds: 0    # 0 = follow session.ttlSeconds (default 7d)
+```
+
+> A minted window must not exceed `client-connection`'s `cookieMaxAgeDays` (default 30); the
+> plugin already clamps to that bound. If you lower `cookieMaxAgeDays` in your deployment, lower
+> `cookieTtlSeconds` to match. Deployments running `trustProxy: false` with dsh's native
+> `--trusted-host <domain>` are covered too: the plugin then mints only the cookie bound to the
+> original public Host, and the fence is satisfied via `trustedHosts`.
 
 ### 4.4 Storage (`lib/store.js`)
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ dsh plugin --profile web remove @xgone/dsh-remote
 | 远程访问时「设置 → 插件」配置页空白 | v0.1.5+ 已内置修复：DSH 对远程浏览器把所有设置 scope 切成 memory 模式（读写在客户端被丢弃），插件启动时自动解除该限制并触发一次全量刷新，配置卡片远程可读可写；原始 settings.yaml 文档编辑器仍保持仅限本机（设计如此） |
 | 远程刷新后反复弹出「内测声明」 | v0.1.6+ 已内置修复（已确认用户）：DSH 的欢迎弹窗确认态 `WelcomeNoticeStore` 对远程走 memory 模式，不读已持久化的确认；插件用官方 `settings.describe` RPC 读 `ui-onboarding.welcomeNoticeVersion`，有值时经官方 `store.update` 置 `acknowledged=true`，`WelcomeNotice` 即自动收场不再弹。全程只用官方 slots/store/RPC，不重写 DSH 内部方法、不改 persistence。纯远程首次用户（从无确认）维持原行为 |
 | 远程打开「设置 → 模型」提示"加载提供方目录失败: settings are unavailable in this browser" | v0.2.6+ 已内置修复：DSH 升级后所有设置读取改经共享的 `SettingsDescribeMirror`（远程构造为 memory 模式，`view` 恒为 undefined），Models 页因此抛错；插件用官方 `settings.describe` RPC 读取设置文档，经官方 `ctx.settingsScope.describe()` 拿到 mirror，再用官方 `store.set` 注入 `view`，Models 目录远程正常加载。全程只用官方 RPC/服务/store API，不重写 DSH 方法、不改 persistence |
+| 升级到 dsh 0.1.2-alpha+ 后，远程登录成功但所有 `/api` 返回 401（index.html 也可能 401） | v0.3.1+ 已内置修复（issue #10）：新版 dsh 的 `client-connection` 额外要求绑定请求 Host 的 `dsh-auth-*` 持久化签名 Cookie，远程浏览器拿不到也无法自行铸造；插件现在在登录时用核心同款算法铸造并下发（绑定归一化 loopback 与原始公网 Host 各一枚），并在门禁层自愈补发——**升级插件后重新登录一次即可**，升级前创建的旧会话会在下一次请求时自动修复 |
 
 ### 9. 无浏览器服务器（headless / Linux）安装
 
@@ -247,6 +248,9 @@ dsh plugin --profile web add @xgone/dsh-remote
     files:
       enabled: true          # 远程文件显示（/auth/file）总开关（默认开）
       maxListing: 500        # 目录索引每页最多渲染的条目数
+    browserAuth:
+      enabled: true          # dsh ≥ 0.1.2-alpha 的 dsh-auth-* Cookie 铸造（默认开，见「3.1」）
+      cookieTtlSeconds: 0    # 0 = 跟随 session.ttlSeconds；上限为 client-connection.cookieMaxAgeDays
 ```
 
 > **角色门禁只作用于 client-request**：`/api/respond`（浏览器应答宿主的 server-request：审批、提问、
@@ -350,6 +354,39 @@ DSH 内置的浏览器信任围栏（`dsh-client-connection`）校验 `Host`（l
 `Host`/`Origin` 归一化为 `127.0.0.1:<端口>`（保留原 scheme）再交给下层——围栏判定为 loopback，
 特权方法对外部浏览器放行。未认证请求仍被门禁 403，围栏的 DNS-rebinding 语义在 Cookie 之后不再
 需要。
+
+### 3.1 新版 dsh 适配：`dsh-auth-*` 会话 Cookie 铸造（≥ 0.1.2-alpha，issue #10）
+
+从 dsh `0.1.2-alpha` 起，`client-connection` 在围栏之外还要求一个**绑定请求 Host** 的持久化签名
+Cookie（`dsh-auth-<sha256(Host)>`，HMAC-SHA256，密钥保存在 `$DSH_HOME/.credentials.yaml` 的
+`client-connection/browser-session` 记录里）：`/api`、流式 WebSocket（`/api/remote.mux`）与
+index.html 都要校验。这个 Cookie 只能由 dsh 自己的 `?token=<启动令牌>` 流程铸造，而远程浏览器
+既拿不到启动令牌，也永远不可能持有绑定 `127.0.0.1:<端口>` 的 Cookie——登录后所有 `/api` 全部
+401。
+
+本插件的适配（默认开启，无需配置）：
+
+- **登录 / MFA / 引导成功时**，插件读取 client-connection 的持久化签名密钥，用与核心完全相同的
+  算法铸造并下发两个 `dsh-auth-*` Cookie：一个绑定**归一化后的 loopback authority**（供 `/api`
+  与 WebSocket 使用），一个绑定**原始公网 Host**（供 index.html / 静态回退路径使用）；
+- **自愈补发**：每个经过门禁的请求都会校验 Cookie 是否在位且有效（包括核心自己铸造的），缺失或
+  失效时在**当前响应**上补发——升级前创建的旧会话、被浏览器清理过 Cookie 的会话，下一次请求即自动
+  修复，无需重新登录；
+- **旧版 dsh 兼容**：读不到 `client-connection/browser-session` 凭证记录（或运行时没有
+  `credentials` 服务）时，铸造逻辑自动关闭，行为与 0.3.0 完全一致。
+
+配置项（通常无需改动）：
+
+```yaml
+browserAuth:
+  enabled: true          # 铸造总开关
+  cookieTtlSeconds: 0    # 0 = 跟随 session.ttlSeconds（默认 7 天）
+```
+
+> Cookie 有效窗口不能超过 `client-connection` 的 `cookieMaxAgeDays`（默认 30 天），插件已自动
+> 收敛到该上限；若你调低了部署里的 `cookieMaxAgeDays`，请把 `cookieTtlSeconds` 一并调低。
+> `trustProxy: false` 且在 dsh 侧配置了 `--trusted-host <域名>` 的部署同样被覆盖：此时插件只铸造
+> 绑定原始公网 Host 的那枚 Cookie，围栏由 `trustedHosts` 放行。
 
 ### 4. 存储（`lib/store.js`）
 

--- a/README.md
+++ b/README.md
@@ -373,7 +373,11 @@ index.html 都要校验。这个 Cookie 只能由 dsh 自己的 `?token=<启动�
   失效时在**当前响应**上补发——升级前创建的旧会话、被浏览器清理过 Cookie 的会话，下一次请求即自动
   修复，无需重新登录；
 - **旧版 dsh 兼容**：读不到 `client-connection/browser-session` 凭证记录（或运行时没有
-  `credentials` 服务）时，铸造逻辑自动关闭，行为与 0.3.0 完全一致。
+  `credentials` 服务）时，铸造逻辑自动关闭，行为与 0.3.0 完全一致；
+- **浏览器半区 RPC 自适应**：alpha 起 RPC endpoint 改名 `namespace/method`（斜杠）且信封收窄为
+  单一 `args` 字段（`settings.describe` → `settings/describe`）。客户端调用先试新形状、404 时回落
+  旧点号形状并按页面缓存，同一份 bundle 同时服务 rc 与 alpha；服务端角色门禁也把斜杠方法名归一化
+  后再匹配点号拒绝表，非管理员限制在两代 dsh 上同样生效。
 
 配置项（通常无需改动）：
 

--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -38,6 +38,15 @@
         rateLimit:
           maxAttempts: 5
           windowMs: 900000
+        # dsh ≥ 0.1.2-alpha compatibility (issue #10): after login this plugin
+        # also mints the core's Host-bound `dsh-auth-*` browser cookie — signed
+        # with client-connection's own persisted secret — so /api, the stream
+        # WebSocket and index.html all authenticate for remote browsers.
+        # cookieTtlSeconds: 0 follows session.ttlSeconds (default; keep it at or
+        # below client-connection's cookieMaxAgeDays, which defaults to 30).
+        browserAuth:
+          enabled: true
+          cookieTtlSeconds: 0
 
 # ── directory picker: force the IN-APP browse backend ────────────────────────
 #

--- a/lib/client.js
+++ b/lib/client.js
@@ -752,19 +752,49 @@ window.__ModuleLoader__.load({
 		}
 
 		/**
-		 * Call one settings RPC through the standard /api client-request
-		 * envelope. Returns the ok result object, or null on any failure —
-		 * callers treat the settings plane as best-effort.
+		 * Call one settings-plane RPC through the standard /api client-request
+		 * envelope. dsh ≥ 0.1.2-alpha renamed the RPC endpoints to
+		 * `namespace/method` (slash) with a single plain-object `args` payload
+		 * field, while rc builds keep dotted names with free-form payloads.
+		 * The first successful call pins the wire shape for this page load; an
+		 * unpinned 404 falls back to the other spelling once, so the same
+		 * bundle serves both dsh generations. Returns the ok result object, or
+		 * null on any failure — callers treat the settings plane as
+		 * best-effort.
 		 */
+		const RPC_SHAPES = {
+			slash: (method, payload) => {
+				const name = method.replaceAll(".", "/");
+				return { path: name, method: name, payload: { args: payload } };
+			},
+			dotted: (method, payload) => ({ path: method, method, payload })
+		};
+		let rpcShape = null;
 		async function settingsRpc(method, payload) {
-			const envelope = await fetchJson(`/api/${method}`, {
-				type: "client-request",
-				rpcId: `dsh-remote-${Math.random().toString(36).slice(2)}`,
-				method,
-				payload
-			});
-			const result = envelope?.result;
-			return result?.ok ? result : null;
+			const order = rpcShape === "slash" ? ["slash"]
+				: rpcShape === "dotted" ? ["dotted"]
+				: ["slash", "dotted"];
+			for (let i = 0; i < order.length; i++) {
+				const form = RPC_SHAPES[order[i]](method, payload);
+				const envelope = await fetchJson(`/api/${form.path}`, {
+					type: "client-request",
+					rpcId: `dsh-remote-${Math.random().toString(36).slice(2)}`,
+					method: form.method,
+					payload: form.payload
+				});
+				const result = envelope?.result;
+				if (result?.ok) {
+					rpcShape = order[i];
+					return result;
+				}
+				// A 404 means this dsh generation does not carry the endpoint
+				// SPELLING — fall through to the other shape once. Business
+				// errors (parsed ok:false envelopes) and network failures stop
+				// the search: retrying cannot help them.
+				if (i < order.length - 1 && envelope !== null && envelope.status === 404) continue;
+				break;
+			}
+			return null;
 		}
 
 		// ── shared field styles ────────────────────────────────────────────────────

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,7 +28,7 @@
 import z from "@deepseek-ai/schemastery";
 import { Readable } from "node:stream";
 import { createGzip } from "node:zlib";
-import { randomUUID, timingSafeEqual } from "node:crypto";
+import { createHash, createHmac, randomUUID, timingSafeEqual } from "node:crypto";
 import { createReadStream, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { basename, dirname, extname, isAbsolute, join, resolve, sep } from "node:path";
 import { dshHomePath } from "@deepseek-ai/dsh-home-paths";
@@ -186,6 +186,26 @@ const Config = z.object({
 		roots: z.array(z.string()).default([]),
 		// Cap entries rendered per directory listing page.
 		maxListing: z.natural().min(10).max(5000).default(500)
+	}).default({}),
+	// dsh ≥ 0.1.2-alpha browser-session cookie minting (issue #10). New dsh
+	// builds gate /api and index.html behind a persistent, Host-bound signed
+	// cookie (`dsh-auth-<sha256(host)>`, verified by client-connection's
+	// browserAuth). Remote browsers can never hold the cookie bound to the
+	// loopback authority this plugin normalizes requests to, so after login
+	// every /api call 401s. This plugin therefore MINTS that cookie itself —
+	// signing it with the same persisted secret client-connection uses (read
+	// through the credentials service) and binding it to the authority the
+	// core will see (loopback under trustProxy, the original Host otherwise).
+	// A self-heal re-mint on gated requests also upgrades sessions created
+	// before this fix. No-op on dsh builds without the credential record.
+	browserAuth: z.object({
+		enabled: z.boolean().default(true),
+		// Minted-cookie lifetime in seconds; 0 follows `session.ttlSeconds`
+		// (the default 7d sits well inside client-connection's default
+		// cookieMaxAgeDays of 30, which bounds the accepted window). Raise
+		// this above the deployment's cookieMaxAgeDays and the core would
+		// reject every minted cookie.
+		cookieTtlSeconds: z.natural().default(0)
 	}).default({})
 });
 
@@ -360,6 +380,136 @@ function isRemoteOrigin(req) {
  *  BEFORE the fence normalization on the gated HTTP/fallback path. */
 function captureOriginalHost(req) {
 	req[ORIGINAL_HOST] = req.headers.host;
+}
+
+// ── dsh browser-session cookie minting (dsh ≥ 0.1.2-alpha, issue #10) ─────────
+// dsh's client-connection plugin authenticates browsers with a persistent,
+// Host-bound signed cookie (`dsh-auth-<sha256(authority)>`): the request Host
+// selects the cookie name AND the payload `authority` must equal it. The
+// functions below mirror packages/client/connection/src/browser-auth.ts
+// (COOKIE_PAYLOAD_VERSION 1) so this plugin can mint cookies the core accepts.
+// Pure helpers, exported for tests.
+
+/** Credential record holding client-connection's persistent signing secret. */
+const BROWSER_SESSION_RECORD_KEY = "client-connection/browser-session";
+
+/** Cookie payload version minted/accepted by dsh core browser-auth v1. */
+const BROWSER_COOKIE_VERSION = 1;
+/** client-connection.cookieMaxAgeDays default — bounds any minted window. */
+const BROWSER_COOKIE_MAX_AGE_DAYS_DEFAULT = 30;
+
+/**
+ * Canonical request authority exactly as dsh core derives it from a Host
+ * header (WHATWG normalization: lowercased host, explicit port kept).
+ * @returns {string|null} canonical `host[:port]`, or null when unparsable.
+ */
+function canonicalAuthority(host) {
+	if (typeof host !== "string" || host === "") return null;
+	try {
+		return new URL(`http://${host}`).host;
+	} catch {
+		return null;
+	}
+}
+
+/** Cookie name for an authority: `dsh-auth-` + base64url(sha256(authority)). */
+function dshAuthCookieName(authority) {
+	return "dsh-auth-" + createHash("sha256").update(authority).digest("base64url");
+}
+
+/**
+ * Serialize one v1 browser-session cookie the way dsh core mints them.
+ * @param {string} authority - bound authority (must match the request Host the core sees).
+ * @param {Buffer} secret - client-connection's persisted signing secret (32 bytes).
+ * @param {number} ttlMs - cookie window; the core rejects windows beyond cookieMaxAgeDays.
+ * @param {number} [nowMs] - issuedAt override (tests).
+ * @returns {{name: string, value: string, cookie: string}} name/value pair plus a full Set-Cookie line.
+ */
+function encodeDshAuthCookie(authority, secret, ttlMs, nowMs = Date.now()) {
+	const issuedAt = nowMs;
+	const expiresAt = issuedAt + ttlMs;
+	const body = Buffer.from(JSON.stringify({
+		version: BROWSER_COOKIE_VERSION,
+		authority,
+		issuedAt,
+		expiresAt
+	}), "utf8").toString("base64url");
+	const sig = createHmac("sha256", secret).update(body).digest("base64url");
+	const name = dshAuthCookieName(authority);
+	const value = `v1.${body}.${sig}`;
+	// Attribute set mirrors dsh core's sessionCookie() exactly.
+	return { name, value, cookie: `${name}=${value}; Max-Age=${Math.floor(ttlMs / 1000)}; Path=/; Expires=${new Date(expiresAt).toUTCString()}; HttpOnly; SameSite=Strict` };
+}
+
+/**
+ * Parse and verify one minted-or-core-minted cookie value (mirror of the
+ * core's decodeCookie + isAuthenticated checks that matter to us).
+ * @returns {object|null} payload when the signature, version, authority and window are live.
+ */
+function decodeDshAuthCookie(value, secret, authority, nowMs = Date.now()) {
+	const parts = String(value ?? "").split(".");
+	if (parts.length !== 3 || parts[0] !== "v1") return null;
+	const [, body, sigB64] = parts;
+	let sig, expected;
+	try {
+		sig = Buffer.from(sigB64, "base64url");
+		expected = createHmac("sha256", secret).update(body).digest();
+	} catch {
+		return null;
+	}
+	if (sig.length !== expected.length || !timingSafeEqual(sig, expected)) return null;
+	let payload;
+	try {
+		payload = JSON.parse(Buffer.from(body, "base64url").toString("utf8"));
+	} catch {
+		return null;
+	}
+	if (payload?.version !== BROWSER_COOKIE_VERSION
+		|| typeof payload.authority !== "string"
+		|| !Number.isSafeInteger(payload.issuedAt)
+		|| !Number.isSafeInteger(payload.expiresAt)) return null;
+	if (payload.authority !== authority) return null;
+	const maxAgeMs = BROWSER_COOKIE_MAX_AGE_DAYS_DEFAULT * 24 * 60 * 60 * 1000;
+	return payload.issuedAt <= nowMs && payload.expiresAt > nowMs
+		&& payload.expiresAt > payload.issuedAt
+		&& payload.expiresAt - payload.issuedAt <= maxAgeMs ? payload : null;
+}
+
+/** Pull one cookie value out of a raw Cookie header (exact name match). */
+function cookieValueOf(cookieHeader, name) {
+	const header = String(cookieHeader ?? "");
+	for (const segment of header.split(";")) {
+		const at = segment.indexOf("=");
+		if (at === -1 || segment.slice(0, at).trim() !== name) continue;
+		return segment.slice(at + 1).trim();
+	}
+	return null;
+}
+
+/**
+ * Validate the stored browser-session credential record and extract the
+ * signing secret (mirror of the core's storedSecret/canonicalSecret).
+ * @returns {Buffer|null} 32-byte HMAC key, or null when absent/malformed.
+ */
+function readBrowserAuthSecret(record) {
+	if (record === null || typeof record !== "object") return null;
+	if (record.kind !== "grant" || record.payload?.version !== 1) return null;
+	const raw = record.payload.secret;
+	if (typeof raw !== "string") return null;
+	const secret = Buffer.from(raw, "base64url");
+	return secret.byteLength === 32 ? secret : null;
+}
+
+/**
+ * Does the request already carry a LIVE dsh-auth cookie for this authority?
+ * Core-minted cookies (direct loopback `?token=` access) validate too — the
+ * name, secret and authority are the same, so there is nothing to re-mint.
+ */
+function hasLiveDshAuthCookie(cookieHeader, authority, secret) {
+	if (!authority || !secret) return false;
+	const value = cookieValueOf(cookieHeader, dshAuthCookieName(authority));
+	if (value === null) return false;
+	return decodeDshAuthCookie(value, secret, authority) !== null;
 }
 
 /** Look up the effective content-type of a response from its resolved headers. */
@@ -613,6 +763,103 @@ function apply(ctx, config) {
 	const secret = cfg.secret && cfg.secret.length >= 32 ? cfg.secret : store.secret;
 	const webServer = ctx.webServer;
 
+	// ── dsh browser-session cookie minting (issue #10) ──────────────────────────
+	// On dsh ≥ 0.1.2-alpha, /api and index.html are gated behind a persistent
+	// Host-bound cookie minted by client-connection's browserAuth. Remote
+	// browsers can never hold the cookie bound to the loopback authority the
+	// gate normalizes requests to (and never hold the launch token to mint
+	// it), so this plugin mints the cookies itself, signed with the SAME
+	// persisted secret client-connection uses. The `credentials` service does
+	// not exist on every dsh build/runtime this plugin supports, so it is
+	// resolved opportunistically — when absent, minting stays off and
+	// behavior is exactly the pre-fix one.
+	let credentialsProvider = null;
+	try {
+		ctx.inject(["credentials"], (credCtx) => {
+			credentialsProvider = credCtx.credentials ?? null;
+		});
+	} catch {
+		// Older runtimes without context.inject semantics: stay mint-free.
+	}
+
+	/** Authority the CORE sees on gated HTTP/upgrade requests (post-normalization). */
+	const gatedAuthority = () => (cfg.trustProxy
+		? `127.0.0.1:${webServer.port ?? "3080"}`
+		: null);
+	/** Authority the CORE sees on fallback/index requests (never normalized). */
+	const originalAuthority = (req) => canonicalAuthority(req[ORIGINAL_HOST] ?? req.headers.host);
+
+	// Secret cache: the record lives in credentials-local's memory map, but the
+	// provider may back onto disk/IPC, so keep a short positive TTL; a negative
+	// probe (old dsh without the record) backs off much longer.
+	let secretCache = null;
+	let lastMissAt = 0;
+	const SECRET_POSITIVE_TTL_MS = 30 * 1000;
+	const SECRET_MISS_TTL_MS = 5 * 60 * 1000;
+	const browserAuthSecret = async () => {
+		if (!cfg.browserAuth.enabled || credentialsProvider === null) return null;
+		const now = Date.now();
+		if (secretCache !== null && now - secretCache.at < SECRET_POSITIVE_TTL_MS) return secretCache.value;
+		if (now - lastMissAt < SECRET_MISS_TTL_MS) return null;
+		try {
+			const record = await credentialsProvider.readRecord(BROWSER_SESSION_RECORD_KEY);
+			const value = readBrowserAuthSecret(record);
+			if (value !== null) {
+				secretCache = { value, at: now };
+				return value;
+			}
+		} catch {
+			// Provider differences must never break the request path.
+		}
+		lastMissAt = now;
+		return null;
+	};
+
+	/** Minted-cookie window: config override, else follow the session TTL. */
+	const cookieTtlMs = () => {
+		const seconds = cfg.browserAuth.cookieTtlSeconds > 0
+			? cfg.browserAuth.cookieTtlSeconds
+			: cfg.session.ttlSeconds;
+		// The core hard-rejects windows beyond its cookieMaxAgeDays (30 by
+		// default) — stay inside that bound no matter how session TTL is set.
+		return Math.min(seconds, BROWSER_COOKIE_MAX_AGE_DAYS_DEFAULT * 24 * 60 * 60) * 1000;
+	};
+
+	/**
+	 * Append one Set-Cookie header unless the request already carries a live
+	 * dsh-auth cookie for `authority` (core-minted or our own). Safe to call
+	 * with the raw res or the gzip wrapper — both forward setHeader-time
+	 * headers into writeHead — and a no-op while headers are already sent.
+	 */
+	const ensureDshAuthCookie = async (res, req, authority) => {
+		if (authority === null || res.headersSent) return;
+		const mintedSecret = await browserAuthSecret();
+		if (mintedSecret === null) return;
+		if (hasLiveDshAuthCookie(req.headers.cookie, authority, mintedSecret)) return;
+		const { cookie } = encodeDshAuthCookie(authority, mintedSecret, cookieTtlMs());
+		res.appendHeader?.("Set-Cookie", cookie);
+	};
+
+	/**
+	 * Login/bootstrap/MFA success: hand the browser every dsh-auth cookie the
+	 * core may demand from it — one bound to the original (public) Host for
+	 * the fallback/index path, and (when the gate normalizes) one bound to the
+	 * loopback authority for /api and the WebSocket upgrade.
+	 */
+	const setLoginDshAuthCookies = async (req, res) => {
+		if (!cfg.browserAuth.enabled) return;
+		const mintedSecret = await browserAuthSecret();
+		if (mintedSecret === null) return;
+		const original = originalAuthority(req);
+		const loopback = gatedAuthority();
+		const authorities = original === null ? [] : [original];
+		if (loopback !== null && loopback !== original) authorities.push(loopback);
+		for (const authority of authorities) {
+			const { cookie } = encodeDshAuthCookie(authority, mintedSecret, cookieTtlMs());
+			res.appendHeader?.("Set-Cookie", cookie);
+		}
+	};
+
 	// ── session signing ─────────────────────────────────────────────────────────
 	const issueSession = (account) => {
 		const payload = {
@@ -790,6 +1037,12 @@ function apply(ctx, config) {
 				outRes = makeGzipRes(res, req, cfg.gzip);
 			}
 			normalizeForFence(req);
+			// Self-heal the dsh browser-session cookie (issue #10): sessions
+			// created before this fix — or browsers whose minted cookie was
+			// evicted — carry only dsh_session, so the core's browserAuth
+			// 401s every /api call. Appending the minted cookie onto THIS
+			// response repairs the jar; the browser's next call succeeds.
+			await ensureDshAuthCookie(outRes, req, gatedAuthority() ?? originalAuthority(req));
 			if (cfg.enforceRoles && verdict.user.role !== "admin") {
 				const gate = await roleGate(req, verdict.user.role);
 				if (!gate.allowed) {
@@ -853,6 +1106,20 @@ function apply(ctx, config) {
 			if (cfg.gzip.enabled) {
 				outRes = makeGzipRes(res, req, cfg.gzip);
 			}
+			// Self-heal the ORIGINAL-Host-bound dsh-auth cookie (issue #10): the
+			// core's index/SPA path (frontend-static → authorizeIndex) validates
+			// against the un-normalized Host, so document-like requests carry the
+			// re-mint on their response when the jar lost it. Asset URLs and the
+			// core's own `?token=` minting are left untouched.
+			if ((req.method === "GET" || req.method === "HEAD") && !/\.[a-z0-9]{1,8}$/i.test(pathnameOf(req))) {
+				try {
+					if (new URL(req.url ?? "/", "http://dsh.internal").searchParams.get("token") === null) {
+						await ensureDshAuthCookie(outRes, req, originalAuthority(req));
+					}
+				} catch {
+					// unparsable URL — nothing to heal
+				}
+			}
 			return handler(req, outRes);
 		};
 		Object.defineProperty(gated, GATED, { value: true });
@@ -912,6 +1179,7 @@ function apply(ctx, config) {
 		store.markLogin(username);
 		store.save();
 		setSessionCookie(res, issueSession(account));
+		await setLoginDshAuthCookies(req, res);
 		json(res, 200, {
 			ok: true,
 			mfa: false,
@@ -970,6 +1238,7 @@ function apply(ctx, config) {
 		store.markLogin(account.username);
 		store.save();
 		setSessionCookie(res, issueSession(account));
+		await setLoginDshAuthCookies(req, res);
 		json(res, 200, { ok: true, user: { username: account.username, role: account.role ?? "user" } });
 	};
 
@@ -1173,6 +1442,7 @@ function apply(ctx, config) {
 		store.save();
 		const account = store.find(username);
 		setSessionCookie(res, issueSession(account));
+		await setLoginDshAuthCookies(req, res);
 		json(res, 200, { ok: true, mfa: false, user: { username, role: "admin" } });
 	};
 
@@ -1599,6 +1869,15 @@ export {
 	ORIGINAL_HOST,
 	captureOriginalHost,
 	isRemoteOrigin,
+	BROWSER_SESSION_RECORD_KEY,
+	BROWSER_COOKIE_MAX_AGE_DAYS_DEFAULT,
+	canonicalAuthority,
+	dshAuthCookieName,
+	encodeDshAuthCookie,
+	decodeDshAuthCookie,
+	cookieValueOf,
+	readBrowserAuthSecret,
+	hasLiveDshAuthCookie,
 	shouldGzip,
 	shouldCache,
 	makeGzipRes,

--- a/lib/index.js
+++ b/lib/index.js
@@ -259,7 +259,10 @@ function evaluateRoleGate(pathname, httpMethod, body, role) {
 	if (envelope?.type !== "client-request" || typeof envelope.method !== "string") {
 		return { allowed: true, body, replayed: true };
 	}
-	const method = envelope.method;
+	// dsh ≥ 0.1.2-alpha names RPC endpoints `namespace/method` (slash) on the
+	// wire while the deny lists above are dotted rc-era names — normalize the
+	// separators before matching so role gating binds on both generations.
+	const method = envelope.method.replaceAll("/", ".");
 	if (NON_ADMIN_DENY.has(method)) return { allowed: false, body, replayed: true };
 	if (role === "guest" && GUEST_DENY.has(method)) return { allowed: false, body, replayed: true };
 	return { allowed: true, body, replayed: true };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xgone/dsh-remote",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Remote access & authentication for the DeepSeek Harness web UI: login gate, MFA (TOTP), signed session cookies, role-based access, in-browser directory picker, account management settings. Fully localized (zh/en).",
   "type": "module",
   "main": "lib/index.js",
@@ -18,8 +18,8 @@
   ],
   "scripts": {
     "check": "node --check lib/index.js",
-    "test": "node --check lib/index.js && node --test test/gzip.test.js test/remote-file.test.js test/role-gate.test.js test/files-store.test.js",
-    "prepublishOnly": "node --check lib/index.js && node --test test/gzip.test.js test/remote-file.test.js test/role-gate.test.js test/files-store.test.js"
+    "test": "node --check lib/index.js && node --test test/gzip.test.js test/remote-file.test.js test/role-gate.test.js test/files-store.test.js test/browser-auth.test.js",
+    "prepublishOnly": "node --check lib/index.js && node --test test/gzip.test.js test/remote-file.test.js test/role-gate.test.js test/files-store.test.js test/browser-auth.test.js"
   },
   "license": "MIT",
   "author": "xgone <xl.gone@gmail.com>",

--- a/test/browser-auth.test.js
+++ b/test/browser-auth.test.js
@@ -1,0 +1,125 @@
+/**
+ * Unit tests for the dsh browser-session cookie minting helpers (issue #10).
+ *
+ * The "interop" vectors below are REAL values captured from a live
+ * dsh 0.1.2-alpha.3 instance: the signing secret as stored in
+ * $DSH_HOME/.credentials.yaml under `client-connection/browser-session`, and a
+ * cookie minted by that instance's own `?token=` exchange. Passing these
+ * proves byte-level compatibility with the core's browser-auth implementation
+ * (packages/client/connection/src/browser-auth.ts), not just self-consistency.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { randomBytes } from "node:crypto";
+import {
+	BROWSER_SESSION_RECORD_KEY,
+	canonicalAuthority,
+	dshAuthCookieName,
+	encodeDshAuthCookie,
+	decodeDshAuthCookie,
+	cookieValueOf,
+	readBrowserAuthSecret,
+	hasLiveDshAuthCookie
+} from "../lib/index.js";
+
+// Live-captured interop vector (see file header).
+const SECRET_B64 = "VXR-ucE76-HH617FbGd5-GNygvIqvPFvAjK9YfVvopM";
+const CORE_AUTHORITY = "127.0.0.1:4123";
+const CORE_COOKIE_NAME = "dsh-auth-YVtZjAk-O-As0CPrK4Smou5Cy2QJPP7nYVHErLbFhXo";
+const CORE_COOKIE_VALUE = "v1.eyJ2ZXJzaW9uIjoxLCJhdXRob3JpdHkiOiIxMjcuMC4wLjE6NDEyMyIsImlzc3VlZEF0IjoxNzg4MzEwOTgzMDg5LCJleHBpcmVzQXQiOjE3OTA5MDI5ODMwODl9.6JAxy85Pvvsx1QCyrpuWqbnk-hFyBO5a1H8A-9SDSfE";
+const CORE_ISSUED_AT = 1788310983089;
+
+test("canonicalAuthority mirrors the core's WHATWG normalization", () => {
+	assert.equal(canonicalAuthority("127.0.0.1:4123"), "127.0.0.1:4123");
+	assert.equal(canonicalAuthority("remote.example.com"), "remote.example.com");
+	assert.equal(canonicalAuthority("Example.COM"), "example.com");
+	assert.equal(canonicalAuthority("example.com:443"), "example.com:443"); // 443 is not http's default port
+	assert.equal(canonicalAuthority("example.com:80"), "example.com"); // 80 is stripped as http default
+	assert.equal(canonicalAuthority("[::1]:8080"), "[::1]:8080");
+	assert.equal(canonicalAuthority(""), null);
+	assert.equal(canonicalAuthority(undefined), null);
+	assert.equal(canonicalAuthority("bad host"), null);
+});
+
+test("cookie name matches the core-derived name for a live authority", () => {
+	assert.equal(dshAuthCookieName(CORE_AUTHORITY), CORE_COOKIE_NAME);
+});
+
+test("decode accepts a cookie minted by the real dsh core", () => {
+	const secret = Buffer.from(SECRET_B64, "base64url");
+	const payload = decodeDshAuthCookie(CORE_COOKIE_VALUE, secret, CORE_AUTHORITY, CORE_ISSUED_AT + 1000);
+	assert.notEqual(payload, null);
+	assert.equal(payload.version, 1);
+	assert.equal(payload.authority, CORE_AUTHORITY);
+	assert.equal(payload.issuedAt, CORE_ISSUED_AT);
+	assert.equal(payload.expiresAt, 1790902983089);
+});
+
+test("encode/decode roundtrip and live-cookie detection", () => {
+	const secret = randomBytes(32);
+	const ttl = 7 * 24 * 60 * 60 * 1000;
+	const now = Date.now();
+	const { name, value, cookie } = encodeDshAuthCookie("remote.example.com", secret, ttl, now);
+	assert.equal(name, dshAuthCookieName("remote.example.com"));
+	assert.ok(cookie.startsWith(`${name}=${value}; Max-Age=604800; Path=/;`));
+	assert.ok(cookie.includes("HttpOnly") && cookie.includes("SameSite=Strict"));
+	const payload = decodeDshAuthCookie(value, secret, "remote.example.com", now + 2000);
+	assert.notEqual(payload, null);
+	assert.equal(payload.issuedAt, now);
+	assert.equal(payload.expiresAt, now + ttl);
+	assert.equal(hasLiveDshAuthCookie(`foo=bar; ${name}=${value}; baz=qux`, "remote.example.com", secret), true);
+	assert.equal(hasLiveDshAuthCookie(`${name}=${value}`, "other.example.com", secret), false);
+	assert.equal(hasLiveDshAuthCookie("unrelated=1", "remote.example.com", secret), false);
+	assert.equal(hasLiveDshAuthCookie(undefined, "remote.example.com", secret), false);
+	assert.equal(hasLiveDshAuthCookie(`${name}=${value}`, "remote.example.com", null), false);
+});
+
+test("decode rejects tampered, foreign, expired and overlong cookies", () => {
+	const secret = randomBytes(32);
+	const { value } = encodeDshAuthCookie("a.example", secret, 1000, 0);
+	// tampered payload
+	const parts = value.split(".");
+	const tamperedBody = Buffer.from(JSON.stringify({ version: 1, authority: "a.example", issuedAt: 0, expiresAt: 900 }), "utf8").toString("base64url");
+	assert.equal(decodeDshAuthCookie(`v1.${tamperedBody}.${parts[2]}`, secret, "a.example", 10), null);
+	// wrong key
+	assert.equal(decodeDshAuthCookie(value, randomBytes(32), "a.example", 10), null);
+	// wrong authority
+	assert.equal(decodeDshAuthCookie(value, secret, "b.example", 10), null);
+	// expired
+	assert.equal(decodeDshAuthCookie(value, secret, "a.example", 1001), null);
+	// overlong window (beyond the core's default cookieMaxAgeDays bound)
+	const { value: overlong } = encodeDshAuthCookie("a.example", secret, 31 * 24 * 60 * 60 * 1000, 0);
+	assert.equal(decodeDshAuthCookie(overlong, secret, "a.example", 10), null);
+	// malformed shapes
+	assert.equal(decodeDshAuthCookie("garbage", secret, "a.example", 10), null);
+	assert.equal(decodeDshAuthCookie("v2.a.b", secret, "a.example", 10), null);
+	assert.equal(decodeDshAuthCookie("v1.a", secret, "a.example", 10), null);
+});
+
+test("readBrowserAuthSecret validates the credential record shape", () => {
+	const secret = readBrowserAuthSecret({
+		kind: "grant",
+		payload: { version: 1, secret: SECRET_B64 }
+	});
+	assert.notEqual(secret, null);
+	assert.equal(secret.byteLength, 32);
+	assert.equal(secret.toString("base64url"), SECRET_B64);
+	assert.equal(readBrowserAuthSecret(undefined), null);
+	assert.equal(readBrowserAuthSecret(null), null);
+	assert.equal(readBrowserAuthSecret({ kind: "api-key", payload: { version: 1, secret: SECRET_B64 } }), null);
+	assert.equal(readBrowserAuthSecret({ kind: "grant", payload: { version: 2, secret: SECRET_B64 } }), null);
+	assert.equal(readBrowserAuthSecret({ kind: "grant", payload: { version: 1, secret: "short" } }), null);
+	assert.equal(readBrowserAuthSecret({ kind: "grant", payload: { version: 1 } }), null);
+});
+
+test("cookieValueOf reads exact names out of a raw Cookie header", () => {
+	assert.equal(cookieValueOf("a=1; dsh_session=v1.x.y; b=2", "dsh_session"), "v1.x.y");
+	assert.equal(cookieValueOf("dsh_session=v1.x.y", "dsh_session"), "v1.x.y");
+	assert.equal(cookieValueOf("x_dsh_session=v1.x.y", "dsh_session"), null);
+	assert.equal(cookieValueOf("", "dsh_session"), null);
+	assert.equal(cookieValueOf(undefined, "dsh_session"), null);
+});
+
+test("the credential record key targets client-connection's browser session", () => {
+	assert.equal(BROWSER_SESSION_RECORD_KEY, "client-connection/browser-session");
+});

--- a/test/role-gate.test.js
+++ b/test/role-gate.test.js
@@ -51,6 +51,19 @@ test("evaluateRoleGate: session.prompt is denied for guest but allowed for user"
 	assert.equal(evaluateRoleGate("/api/session.prompt", "POST", clientRequest("session.prompt"), "user").allowed, true);
 });
 
+test("evaluateRoleGate: dsh alpha slash endpoint names hit the dotted deny lists", () => {
+	// dsh ≥ 0.1.2-alpha names RPC endpoints `namespace/method` on the wire;
+	// the deny lists are dotted rc-era names, so the gate normalizes the
+	// separators before matching — otherwise role gating silently stops
+	// binding on alpha builds.
+	assert.equal(evaluateRoleGate("/api/host/pickDirectory", "POST", clientRequest("host/pickDirectory"), "user").allowed, false);
+	assert.equal(evaluateRoleGate("/api/settings/describe", "POST", clientRequest("settings/describe"), "user").allowed, false);
+	assert.equal(evaluateRoleGate("/api/session/prompt", "POST", clientRequest("session/prompt"), "guest").allowed, false);
+	// non-deny methods still pass under both spellings. (Admins never reach
+	// this pure function — wrapHttp skips it for the admin role.)
+	assert.equal(evaluateRoleGate("/api/workspace/list", "POST", clientRequest("workspace/list"), "guest").allowed, true);
+});
+
 test("evaluateRoleGate: workspace.list is allowed for every role", () => {
 	for (const role of ["admin", "user", "guest"]) {
 		assert.equal(evaluateRoleGate("/api/workspace.list", "POST", clientRequest("workspace.list"), role).allowed, true, role);


### PR DESCRIPTION
## 背景 / Problem

Fixes #10。

dsh ≥ `0.1.2-alpha` 在 `/api`、WS 多路复用器与 `index.html` 上新增了 browserAuth 层:要求请求携带由核心铸造的、**绑定 Host 的 HMAC cookie**(`dsh-auth-<hash(host)>`,密钥存于 credentials 服务的 `client-connection/browser-session` 记录)。反向代理/公网 Host 场景下的远程浏览器:

1. 永远无法持有绑定 loopback authority 的 cookie(本插件 `normalizeForFence` 把请求归一化成 `127.0.0.1:<port>` 再交给核心);
2. 也没有启动 token,无法走核心自己的 `/?token=` 配对流程 → 所有 `/api` 与 index 请求 401(`dsh web authentication required`)。

连带问题:dsh alpha 起 RPC endpoint 改名为 `namespace/method`(斜杠)且信封收窄为单一 `args` 字段,浏览器半区的 settings 回流(`settings.describe` 等)在新版上静默 404。

## 改动 / Changes(2 commits)

**`3eaf7ea` — Host 半区:为 dsh ≥ 0.1.2-alpha 铸造 browser cookie(issue #10 主体)**

- 登录 / MFA / bootstrap 成功时,经 `ctx.inject(["credentials"])` 读取核心密钥,按核心同款算法铸造两枚 cookie:绑定 loopback authority(给归一化后的 `/api` + WS mux)与绑定原始公网 Host(给未归一化的 index 路径);
- `/api` 401 时自愈:补发 `Set-Cookie` 后客户端重试即恢复,**旧会话无需重新登录**;
- 配置新增 `browserAuth: { enabled: true, cookieTtlSeconds: 0 }`(0 = 跟随 `session.ttlSeconds`);
- **旧版 dsh 自动关闭**:读不到 `client-connection/browser-session` 凭证记录(或无 `credentials` 服务)时铸造逻辑静默 no-op,行为与 0.3.0 一致。

**`31f719b` — 双代 wire 形状自适应 + 角色门禁归一化**

- 浏览器半区 `settingsRpc`(settings.describe ×3、settings.mutate、host.pickDirectory)先试斜杠新形状,404 回落点号旧形状,并按页缓存命中形状 —— 一份 bundle 同时服务 rc 与 alpha;
- Host 半区角色门禁:alpha wire 的斜杠方法名归一化为点号后再匹配 `NON_ADMIN_DENY` / `GUEST_DENY`(否则 alpha 上非管理员限制静默失效,guest 可达 `session/prompt`)。

## 与 #11 的关系

#11 正确发现了 settings RPC 改名导致回流失效的问题 —— 本分支已采纳该发现并致谢。但 #11 的实现存在三个问题,本分支以不同方式覆盖:

1. **无条件改名会反向破坏 rc 版本**:rc 上斜杠 endpoint 是 404(两个方向均已实测)。本分支用形状探测 + 回落,不做版本硬编码;
2. **`/?token=` 在 `requireAuth` 之前放行**:`rc` 系 dsh 没有 browserAuth/launch token 校验,`/?token=任意值` 会直接绕过登录页把 SPA 渲染出去,破坏"除 `/auth/*` 外全路由门禁"的承诺;
3. **依赖手工 token 配对**:每个浏览器需要从服务器控制台拿 token 访问一次,cookie 被清除后需要重来。本分支登录即配对 + 401 自愈,零手工步骤、无需暴露启动 token。

建议关闭 #11,以本分支为准。

## 测试 / Verification

- 单元测试 **50/50**(含与 dsh 核心互操作的 cookie 黄金向量、斜杠方法名门禁用例);
- 三代 dsh 实测矩阵(公网 Host + 反代语义,`trustProxy: true`,无 `--trusted-host`):

| dsh 版本 | 回归 | cookie 铸造 | settings RPC | 角色门禁 | 日志 |
|---|---|---|---|---|---|
| `0.1.1-rc.2`(当前在用) | 全绿 | 自动关闭(0 枚 dsh-auth,行为同 0.3.0) | 点号 ✓ | 归一化双向不破坏 | 0 错误 |
| `0.1.2-alpha.3` | 10/10 | 登录铸造 2 枚 + 自愈 | 斜杠 ✓ | guest 斜杠 prompt 被拒 | 0 错误 |
| `0.1.2-alpha.4`(最新) | 10/10 | 登录铸造 2 枚 + 自愈 | 斜杠 ✓ | guest 斜杠 prompt 被拒 | 0 错误 |

回归覆盖:登录 cookie 数量、`/api` 真实 RPC、index 200、仅 `dsh_session` 的旧会话 401 自愈重试、未认证 403/登录页、伪造 `dsh-auth` cookie 仍 401。

未发布 npm。
