### PR TITLE
docs: slim READMEs; move updates & technical details to dedicated files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,96 @@
+# 更新记录（Changelog）
+
+用户指南见 [README](README.md)；实现细节见 [docs/REFERENCE.md](docs/REFERENCE.md)。
+
+## 0.3.1 (2026-09-02)
+
+- **适配 dsh ≥ 0.1.2-alpha（issue #10）**：新版 dsh 的 `client-connection` 额外要求绑定请求 Host 的 `dsh-auth-*` 持久化签名 Cookie，远程浏览器拿不到，导致登录成功后所有 `/api` 返回 401（index.html 也可能 401）。插件现在在登录 / MFA / 引导成功时用核心同款算法铸造并下发两枚 Cookie（分别绑定归一化 loopback 与原始公网 Host），并在门禁层自愈补发。**升级插件后重新登录一次即可**；升级前创建的旧会话在下一次请求时自动修复，无需重新登录。
+- 浏览器半区 RPC 自适应 alpha 的 `namespace/method` 斜杠端点（404 时回落旧点号形状并按页面缓存），同一份 bundle 同时服务 rc 与 alpha；服务端角色门禁把斜杠方法名归一化后再匹配拒绝表，非管理员限制在两代 dsh 上同样生效。
+
+## 0.3.0 (2026-08-31)
+
+- **允许的目录可在设置页管理**：管理员在 Settings → 登录与账号 → 允许的目录 添加 / 删除，即时生效、无需重启、持久化到 `$DSH_HOME/dsh-remote-files.json`；配置文件提供的根目录转为只读展示，旧配置项 `files.roots` 兼容保留。
+- 修复 `host.openPath` 拦截响应缺少 `type: "server-response"` 导致的客户端解析错误。
+
+## 0.2.8 (2026-08-24)
+
+- 界面跟随 DSH 浅色 / 深色主题：全部界面改用官方设计令牌（`--dsw-alias-*`）取色，自动跟随 DSH 外观设置，无需插件自身主题配置（PR #7）。
+
+## 0.2.7 (2026-08-22)
+
+- 角色门禁只对 `client-request` 封包按方法判定，其余 wire 协议消息（`/api/respond` 的 server-request 应答等）一律放行；被拒的 client-request 返回符合 RPC 契约的错误封包（回显 rpcId）。修复非 admin 角色下宿主挂起的流式请求失败、WebSocket 反复重连、工作区 / 会话基线被重置。
+
+## 0.2.6 (2026-08-22)
+
+- 为远程浏览器播种 settings describe mirror：新版 DSH 把所有设置读取改经共享的 `SettingsDescribeMirror`（远程构造为 memory 模式，`view` 恒为 undefined），远程打开「设置 → 模型」报 "加载提供方目录失败"。插件用官方 `settings.describe` RPC 读取设置文档并经官方 `store.set` 注入 view，Models 目录远程正常加载。
+
+## 0.2.5 (2026-08-20)
+
+- 测试：目录大小写不敏感用例适配大小写敏感的 CI 主机。
+
+## 0.2.4 (2026-08-20)
+
+- Windows 下路径 / 根目录比较做大小写折叠（`E:\code` 与 `E:\CODE` 等价）。
+
+## 0.2.3 (2026-08-20)
+
+- 文件面板被拒（`outside-roots`）时，提示中直接列出当前允许的目录（`allowedRoots`）。
+
+## 0.2.2 (2026-08-20)
+
+- 文件面板拦截判定改由 `location.hostname` 决定，修复本机经非 loopback 主机名访问时被误拦截。
+
+## 0.2.1 (2026-08-20)
+
+- 修复浏览器半区 `connection` 依赖的 inject 声明顺序。
+
+## 0.2.0 (2026-08-20)
+
+- **远程文件面板**：DSH 点击文件路径原本在宿主机桌面打开（远程用户不可见），现在远程浏览器改为在右侧边栏面板中显示——Markdown 按界面排版渲染、图片 / PDF / 视频内联、文本等宽预览、目录逐级浏览；支持多面板上下等分分割、面板最大化、侧栏拖拽调宽、Esc 关闭（PR #3）。
+
+## 0.1.9 (2026-08-20)
+
+- 响应 gzip 压缩：认证后的 HTML / CSS / JS / JSON / SVG 等自动压缩（默认仅远程），带 rev 的静态资源加 `Cache-Control: immutable`（PR #1）。
+- 移动端输入框 Enter 换行而非发送（PR #2）。
+
+## 0.1.8 (2026-08-18)
+
+- 修复欢迎声明补丁的 inject 读取路径（顶层 `entry.inject`）；移除诊断日志。
+
+## 0.1.7 (2026-08-18)
+
+- 内部诊断版本（定位 0.1.6 修复的失效原因），无用户可见变化。
+
+## 0.1.6 (2026-08-18)
+
+- 远程浏览器不再反复弹出「内测声明」：对已持久化确认的用户，经官方 `settings.describe` / `store.update` 回放确认态。纯远程首次用户维持原行为。
+- README 增加登录页 / 设置页截图。
+
+## 0.1.5 (2026-08-17)
+
+- 修复远程浏览器「设置 → 插件」配置卡片空白：DSH 对远程把所有 settings scope 切成 memory 模式（读写在客户端被丢弃），插件启动时解除该限制并触发全量刷新；原始 settings.yaml 文档编辑器仍保持仅限本机。
+- 修复 DSH rc.7 启动崩溃（移除 schemastery `.optional()`）。
+
+## 0.1.4 (2026-08-17)
+
+- 无浏览器服务器（headless）：支持用 `bootstrap` 配置节在启动时预置首个管理员（幂等，账号库非空即忽略）。
+
+## 0.1.3 (2026-08-17)
+
+- npm 检索元数据：关键词、包描述补充 MFA 与本地化信息。
+
+## 0.1.2 (2026-08-17)
+
+- **中英双语**：登录页与全部应用内界面提供 zh / en，跟随 DSH 应用语言（Settings → General → Language）实时切换；新增英文 README。
+- 远程浏览器语言偏好持久化：语言切换经官方 `settings.mutate` RPC 落盘 `settings.yaml`，修复 DSH 原生机制下远程刷新即丢的问题。
+
+## 0.1.1 (2026-08-17)
+
+首个公开发布：
+
+- 登录门禁（未登录任何路径 → 登录页；`/api` 与 WebSocket 要求会话 Cookie）；
+- 账号体系：scrypt 哈希、HMAC-SHA256 签名会话、登录限速、首个管理员 loopback 引导且受保护、adminOnly 默认开启（可选 admin/user/guest 三角色）；
+- MFA（TOTP，RFC 6238）：扫码绑定、手动密钥、10 个一次性备用码（仅存哈希）、管理员恢复；
+- 工作区目录选择器替换为浏览器内对话框（不弹宿主机原生窗口）；
+- trustProxy：认证后归一化 Host/Origin，放行 DSH 钉死在 loopback 的特权方法；
+- 反向代理部署指引与 npm 发布流水线。

--- a/README.en.md
+++ b/README.en.md
@@ -5,10 +5,9 @@
 
 **[English](README.en.md)** | [中文](README.md)
 
-**Make DeepSeek Harness safely accessible remotely**: a full account/password authentication +
-MFA (two-factor) gate in front of `dsh web`, plus everything needed for remote deployments — an
-external browser can sign in and use the full feature set (including workspace selection and
-"Add workspace"), without any native window ever popping up on the host machine.
+**Make DeepSeek Harness safely accessible remotely**: an account/password + MFA (two-factor)
+gate in front of `dsh web` — an external browser signs in and gets the full feature set, with no
+native window ever popping up on the host machine.
 
 ### Screenshots
 
@@ -16,539 +15,60 @@ external browser can sign in and use the full feature set (including workspace s
 |:---:|:---:|
 | ![Login page](docs/login-en.png) | ![Account management settings](docs/settings-en.png) |
 
----
+## Features
 
-## 1. Features (user perspective)
+- **Remote access**: once exposed behind a reverse proxy (nginx / ssh tunnel / Tailscale / Frp,
+  …), an external browser can sign in and use everything; selecting / creating a workspace is an
+  in-browser directory dialog — no host OS dialogs; WebSocket event streams work end to end.
+- **Login gate**: unauthenticated access to any path gets the login page; `/api` and WebSocket all
+  require a valid session; passwords are scrypt-hashed, failed logins are rate limited, and the
+  first admin can only be created from the local machine.
+- **MFA two-factor (TOTP)**: works with standard authenticators (Google Authenticator /
+  1Password / Authy), scan-to-bind + 10 one-time backup codes; an admin can disable MFA for any
+  account if the phone is lost.
+- **Remote file panel**: clicking a file path opens it in a right-side panel instead of a host
+  desktop app (Markdown / image / PDF / text / directory browsing). Only the DSH home directory
+  and the working directory are readable by default; admins can allow more directories from the
+  settings page.
+- **Multi-account (optional)**: admin-only by default; turn off `adminOnly` to enable
+  admin / user / guest roles.
+- **Follows DSH**: light / dark theme automatically; English and Chinese follow the DSH app
+  language.
+- **Faster remote access**: responses are gzipped automatically (remote browsers by default) and
+  hashed assets play nicely with edge caches.
 
-### 1.1 Remote access to dsh
+## Getting started
 
-- **Works over the internet / LAN**: once exposed behind a reverse proxy (nginx / ssh tunnel /
-  Tailscale / Frp, …), an external browser can sign in and use everything. DSH's built-in `/api`
-  trust fence hard-codes privileged methods (`host.pickDirectory`, `settings.*`, `credentials.*`,
-  …) to loopback (the official note says "until a real authentication layer exists") — this plugin
-  is that authentication layer and lets them through after authentication.
-- **No host OS dialogs for workspace selection**: DSH's default directory picker calls the host's
-  native OS chooser on loopback deployments (invisible to remote users). This plugin swaps the
-  picker to the **browse backend** — selecting/creating a workspace becomes an **in-browser
-  directory dialog** (two-pane directory view + breadcrumbs + "new folder").
-- **WebSocket works end to end**: the event downlinks (`events.mux` / `events.host`) establish
-  normally after authentication.
-
-### 1.2 Account/password authentication
-
-- **Complete login gate**: unauthenticated access to any path gets a self-contained login page;
-  `/api` and WebSocket all require a valid session cookie.
-- **Secure sessions**: HMAC-SHA256-signed HttpOnly cookies (configurable expiry, Secure,
-  SameSite); the signing secret is randomly generated and persisted (sessions survive restarts).
-- **Passwords stored safely**: scrypt hashes (`N=16384,r=8,p=1`) + constant-time comparison,
-  plaintext is never written to disk.
-- **Brute-force protection**: failed logins are rate limited per IP + username (default 5 attempts
-  in a 15-minute window).
-- **First-run bootstrap**: when no account exists, the login page offers "create the first admin",
-  submit only from the local machine (loopback) to prevent remote pre-registration.
-- **First account is protected**: the root account cannot be deleted or re-roled, only its
-  password can be reset (prevents locking yourself out by deleting the only admin).
-- **Admin-only mode (default)**: creating accounts at runtime is refused, every account is forced
-  to the admin role, and the "add account" form is hidden in Settings; set `adminOnly: false` to
-  re-enable multi-role account management.
-- **Optional roles**: with `adminOnly` off, three method-level roles are available —
-  `admin` / `user` / `guest`.
-
-### 1.3 MFA two-factor authentication (TOTP)
-
-- **Works with standard authenticators**: Google Authenticator, 1Password, Authy, … (RFC 6238,
-  6 digits / 30 s).
-- **Scan-to-bind**: enabling shows a QR code (SVG, verified scannable) + manual secret + otpauth
-  link + 10 one-time backup codes (backup codes are stored as SHA-256 hashes only).
-- **Live verification on sign-in**: the login page and the re-login overlay show a "valid for Ns"
-  countdown and **auto-submit** once 6 digits are entered (backup codes contain letters and still
-  use the button).
-- **Admin recovery**: an admin can disable MFA for any account using their own password.
-
-### 1.4 UX details
-
-- The login page is a complete auth surface on its own: password → code / in-place binding guide
-  (with QR code);
-- When the session expires, a full-screen re-login overlay appears inside the SPA with
-  auto-verify input;
-- Settings → Auth & Accounts: MFA self-service (enable/disable), account list (card style), reset
-  password, log out button.
-
-### 1.5 Localization (`zh` / `en`)
-
-Every plugin surface — the login page, MFA binding guide, re-login overlay, and the Settings →
-Auth & Accounts page — ships in both English and Chinese, following the **DSH app language**
-(Settings → General → Language):
-
-- **Login page**: server-rendered; prefers `locale.preference` in `$DSH_HOME/settings.yaml` (the
-  DSH app language) and falls back to the browser's `Accept-Language` when unset;
-- **In-app UI**: wired into the official `@deepseek-ai/dsh-client-locale` service (`ctx.locale`) —
-  the plugin registers its zh/en dictionaries and follows language switches live: the settings
-  page and overlays update instantly, no refresh needed.
-
-**Remote-browser language persistence**: by design DSH pins the whole settings plane to loopback
-— settings reads/writes from non-loopback (remote) browsers stay in memory, so the language
-preference reverts on every refresh under DSH's native mechanism. As the authentication layer for
-remote deployments, this plugin takes over both directions of the language preference for
-non-loopback browsers:
-
-- **Read**: at boot, the persisted preference is fetched via the standard `settings.describe` RPC
-  and applied to the UI (the login page reads the same preference server-side);
-- **Write**: every language switch is mirrored into `settings.yaml` via the standard
-  `settings.mutate` RPC — consistent across browsers and devices.
-
-Local (`127.0.0.1` / `localhost`) access keeps DSH's native host-backed path untouched. Both
-directions use the same standard RPC envelope DSH's own UI uses — no host internals are patched.
-
-**Light / dark theme**: every plugin surface (login page, MFA setup, re-auth overlay, settings
-page, remote file panel) takes its colors from DSH's official design tokens (`--dsw-alias-*`),
-so it follows DSH's appearance setting (light / dark / system) automatically — no separate theme
-configuration.
-
----
-
-## 2. Installation
-
-### 2.0 Prerequisites
-
-- DeepSeek Harness installed and able to run `dsh web` (default port 3080);
-- A `web` profile initialized (running `dsh web` once does this automatically);
-- `pnpm` on PATH (`dsh plugin` uses it to manage profile plugins).
-
-### 2.1 Install the plugin package
-
-**Install from npm (recommended)** — the plugin is published on the npm registry:
+### 1. Install
 
 ```sh
 dsh plugin --profile web add @xgone/dsh-remote
 ```
 
-> - Package page: https://www.npmjs.com/package/@xgone/dsh-remote
-> - Pin a version: `dsh plugin --profile web add @xgone/dsh-remote@0.1.1`
+### 2. Restart `dsh web`
 
-Other ways to install:
-
-```sh
-# From the public Git repository
-dsh plugin --profile web add git@github.com:xgone/dsh-remote.git
-
-# From a local source checkout (development / personal use — adjust the path)
-dsh plugin --profile web add ~/path/to/dsh-remote
-```
-
-`dsh plugin` does three things:
-
-1. Installs the package with pnpm under `~/.dsh/profiles/web/` (output `+ @xgone/dsh-remote`
-   means success);
-2. Automatically appends `@xgone/dsh-remote` to the profile's `dsh.profile.bundles` (the package
-   declares `dsh.bundle.patch`) — no manual config needed;
-3. The plugin takes effect at the next boot's composition.
-
-### 2.2 Verify the install
+Patches cannot hot-reload — a restart is required:
 
 ```sh
-# dsh-remote should appear in the bundles list
-python3 -c "import json; print(json.load(open('$HOME/.dsh/profiles/web/package.json'))['dsh']['profile']['bundles'])"
-# Expected output similar to: ['@deepseek-ai/dsh-base', '@deepseek-ai/dsh-web-app', '@xgone/dsh-remote']
-```
-
-### 2.3 Restart `dsh web`
-
-HMR is disabled on the web surface, so a patch cannot hot-reload — **a restart is required**:
-
-```sh
-# Stop the current dsh web process and start it again (or restart your launcher)
 dsh web
 ```
 
-### 2.4 First boot: create the admin
+### 3. Create the first admin
 
-After restarting, open `http://127.0.0.1:3080` in your browser:
+Open `http://127.0.0.1:3080` in a local browser: the login page is in bootstrap mode — enter a
+username and password (at least 6 characters) to create the first admin, and you are signed in.
 
-1. An unauthenticated visit shows the **login page** (self-contained, not an SPA);
-2. With no account yet, the login page is in **bootstrap mode**: the title reads "Create the first
-   admin account";
-3. Enter a username and password (at least 6 characters) and click create — **loopback only**, to
-   prevent remote pre-registration;
-4. Creation signs you in immediately (a session cookie is issued).
+> Server without a local browser? See [Headless servers](#headless-servers-no-local-browser).
 
-> Verify: `curl http://127.0.0.1:3080/auth/me` should return
-> `{"authEnabled":true,"bootstrap":false,"authenticated":true,...}`.
+### 4. Bind MFA (recommended)
 
-### 2.5 Bind MFA (recommended)
+Go to **Settings → Auth & Accounts → Two-factor authentication (MFA) → Enable**, scan the QR code
+with your authenticator and enter the 6-digit code. **Save the 10 backup codes first.**
 
-After signing in, go to **Settings → Auth & Accounts → Two-factor authentication (MFA) → Enable
-two-factor**:
+### 5. Remote access
 
-1. The page shows a **QR code** (scan with Google Authenticator / 1Password / Authy);
-2. It also shows the manual secret, the otpauth link and **10 one-time backup codes** — save the
-   backup codes first;
-3. Enter the current 6-digit code from your authenticator → it auto-verifies and enables;
-4. Every sign-in afterwards requires password + code (or backup code).
-
-> You don't have to enter Settings: after the password step, the login page itself offers the
-> "bind two-factor" guide when MFA is not yet enabled.
-
-### 2.6 Verify the installation
-
-- Unauthenticated visit to any path → login page; calling `/api` directly → 403;
-- After signing in, `/api`, the WebSocket event stream and workspace selection (in-browser
-  directory dialog) all work;
-- After the session expires (or you log out) you return to the login page.
-
-### 2.7 Uninstall
-
-```sh
-dsh plugin --profile web remove @xgone/dsh-remote
-```
-
-`dsh plugin` runs pnpm remove and automatically drops the package from `dsh.profile.bundles`;
-after restarting `dsh web` the gate is gone. `$DSH_HOME/auth/store.json` and the account data are
-kept (delete that file manually if you want a complete reset).
-
-### 2.8 FAQ
-
-| Symptom | Fix |
-|---|---|
-| No login page after install | Not restarted: run `dsh web` again; or `@xgone/dsh-remote` is missing from the bundles list (re-run `dsh plugin --profile web add ...`) |
-| Login form submits but nothing happens | Make sure username/password are filled; `content-script.js` errors in the browser console are extension noise and can be ignored |
-| 403 when creating the admin | bootstrap is loopback-only: operate from a local browser, or access `127.0.0.1` through `ssh -L`; on a server without a local browser use the `bootstrap` config below to provision the first admin |
-| Locked out (misconfiguration) | Set `enabled: false` in `cordis.patch.yml` and restart; or delete `$DSH_HOME/auth/store.json` to re-enter bootstrap mode |
-| Lost MFA / phone | An admin can sign in and go to Settings → Auth & Accounts → that account row → Disable MFA (requires the admin password) |
-| Settings → Plugins config page is blank over remote access | Built-in fix since v0.1.5: DSH switches every settings scope to memory mode for remote browsers (reads and writes are dropped client-side); the plugin unpins the scope queue at startup and triggers a full refresh, so the config cards are readable and writable remotely. The raw settings.yaml document editor intentionally stays loopback-only |
-| "Internal Testing Notice" re-pops on every remote refresh | Built-in fix since v0.1.6 (for users who already acknowledged): DSH's welcome-notice acknowledgement (`WelcomeNoticeStore`) runs in memory mode for remote browsers, so the persisted ack is never read; the plugin reads `ui-onboarding.welcomeNoticeVersion` through the official settings.describe RPC and, when one exists, sets the live store's `acknowledged` flag via the official `store.update` API — WelcomeNotice then auto-finishes and the notice stops re-popping. Uses only official slots/store/RPC; no DSH internals rewritten, no persistence flipped. First-time remote users (no ack yet) keep the original behavior |
-| Opening Settings → Models remotely fails with "Failed to load provider catalog: settings are unavailable in this browser" | Built-in fix since v0.2.6: the upgraded DSH routes every settings read through a shared `SettingsDescribeMirror` that is constructed in memory mode for remote browsers (view always undefined), so the Models page rejects. The plugin reads the settings document through the official settings.describe RPC, reaches the mirror through the official `ctx.settingsScope.describe()` service, and folds the document in through the official `store.set` API — the provider catalog loads normally remotely. Uses only official RPC/service/store APIs; no DSH methods rewritten, no persistence flipped |
-| After upgrading to dsh 0.1.2-alpha+, remote login succeeds but every `/api` call returns 401 (index.html may 401 too) | Built-in fix since v0.3.1 (issue #10): the new dsh `client-connection` additionally requires a persistent signed `dsh-auth-*` cookie bound to the request Host, which a remote browser can never obtain or mint; the plugin now mints and sets it at login with the exact core algorithm (one bound to the normalized loopback authority, one to the original public Host) and self-heals at the gate — **upgrade the plugin and sign in once more**; sessions created before the upgrade repair themselves on the next request |
-
-### 2.6 Headless / Linux server install (no local browser)
-
-On a server without a local browser the "create the first admin" flow (loopback-only) is
-unreachable. Provision the first admin at startup from config instead — equivalent to the
-loopback bootstrap: same root protection, admin role, scrypt hashing:
-
-```sh
-dsh plugin --profile web add @xgone/dsh-remote
-# edit ~/.dsh/profiles/web/cordis.patch.yml and add a config to the remote row:
-```
-
-```yaml
-- id: remote
-  config:
-    enabled: true
-    bootstrap:
-      username: admin          # created on first start (only while the account store is empty)
-      password: 'pick-a-strong-password'
-```
-
-Notes:
-
-- **Idempotent**: once any account exists the config is ignored (the log tells you to remove the
-  credentials); it never recreates an account or overwrites an existing password;
-- The password must be at least 6 characters (same rule as the UI bootstrap); a violation fails
-  startup with a clear error;
-- The first account behaves exactly like a UI bootstrap: `protected: true` (cannot be deleted or
-  re-roled, password resettable only);
-- After first login, remove the config block (leaving it is harmless — it is dead once accounts
-  exist); you can bind MFA afterwards in Settings → Auth & Accounts;
-- Reverse-proxy deployments only need `trustProxy: true` (already the default).
-
-## 3. Configuration (`cordis.patch.yml`)
-
-```yaml
-# ~/.dsh/profiles/web/cordis.patch.yml (overrides the whole config of the `remote` row;
-# unlisted keys fall back to schema defaults)
-- id: remote
-  config:
-    enabled: true
-    accounts: []            # seed accounts (plaintext passwords are hashed with scrypt at boot; or pass scrypt$<salt>$<hash> directly)
-    secret: ''              # empty = auto-generate and persist
-    session:
-      cookieName: dsh_session
-      ttlSeconds: 604800    # 7 days
-      secure: false         # set true for HTTPS deployments
-      sameSite: lax
-    enforceRoles: true      # admin/user/guest method-level permissions
-    adminOnly: true         # admin accounts only (default)
-    trustProxy: true        # normalize Host/Origin of authenticated requests (default)
-    bootstrap:
-      username: admin       # optional: provision the first admin on headless servers (only while the store is empty)
-      password: '...'
-    mfa:
-      enabled: true
-      issuer: DeepSeek Harness
-      window: 1             # allow ±1 30-second step
-      backupCodes: 10
-    rateLimit:
-      maxAttempts: 5
-      windowMs: 900000
-    gzip:
-      enabled: true          # master switch for response gzip compression (default on)
-      remoteOnly: true       # compress only remote (non-loopback Host) requests; false compresses local too
-      minBytes: 1024         # skip compression when a known Content-Length is below this
-    files:
-      enabled: true          # master switch for remote file display via /auth/file (default on)
-      maxListing: 500        # max entries rendered per directory listing page
-    browserAuth:
-      enabled: true          # mint dsh-auth-* cookies on dsh >= 0.1.2-alpha (default on, see 4.3.1)
-      cookieTtlSeconds: 0    # 0 = follow session.ttlSeconds; capped by client-connection.cookieMaxAgeDays
-```
-
-> **Windows note**: the directories readable by default are the DSH home dir and the dsh
-> process working directory (usually the profile dir), while workspace files often live on
-> other drive paths. When the pane reports `outside-roots`, sign in as an admin, open
-> **Settings > Auth & Accounts > Allowed directories**, and add the workspace directory
-> there (e.g. `E:\CODE`; both `E:/CODE` and `E:\\CODE` spellings are accepted in the input)
-> — **applied immediately, no config edit, no restart**.
-
-Disable authentication entirely: `enabled: false`.
-
-**Remote file display**: clicking a file path in the DSH web UI fires the `host.openPath`
-RPC, which hands the path to the **host** desktop's default application — invisible to a
-remote browser user. This plugin intercepts that RPC for remote (non-loopback) browsers and
-shows the file in a **right side panel** instead (host-streamed `/auth/file`, Claude
-Desktop-style):
-- markdown renders with the shell's own markdown renderer; images / PDF / video display
-  inline; text and code preview monospaced; directories navigate level by level
-- **multiple panes** can be open at once and split the panel vertically; every pane has its
-  own maximize (fill the whole sidebar, toggleable) and close button in its top-right corner
-- each pane's header shows the file name and full path; the sidebar's left edge is draggable
-  to resize; Esc closes the maximized / topmost pane
-- non-previewable binaries fall back to download / open-in-new-tab
-
-DSH's native right "details" column (session details, single slot) is untouched — this
-sidebar coexists with it as an overlay. **Which files can be viewed by default?** Only
-files inside the DSH home directory and the dsh process working directory; anything else
-makes the pane report `cannot display file (outside-roots)`. Every read is realpath-checked,
-so symlink escapes and `..` traversal are rejected; loopback browsers keep DSH's native
-behavior. `files.enabled: false` turns it off entirely.
-
-> **How to allow other directories (done on the settings page — no config edit)**
->
-> 1. Sign in as an **admin** and open **Settings > Auth & Accounts > Allowed directories**;
-> 2. click **Pick directory** to choose a folder on the host, or paste an absolute path into
->    the input, then click **Add**;
-> 3. the change **applies immediately, no restart** — click the file path in the session
->    again and it now renders;
-> 4. when it is no longer needed, click **Remove** on that entry to revoke access.
->
-> Added directories persist in `$DSH_HOME/dsh-remote-files.json` (0600, written atomically)
-> and survive restarts; config-provided roots are listed read-only alongside and are not
-> managed from the page. The legacy `files.roots` config option still works (also shown
-> read-only), but **new directories should be added through the settings page**. The
-> `allowedRoots` hint shown on a rejected panel points straight at this settings page.
-
-
-**Response gzip compression**: the plugin gzips compressible responses (HTML / CSS / JS /
-JSON / SVG / manifest, etc.) served to **authenticated** clients, noticeably shrinking large
-history loads and big static bundles over a remote tunnel, and adds `Cache-Control: immutable`
-plus `CDN-Cache-Control` to rev-hashed assets so Cloudflare and similar edges cache them. By
-default it compresses **only remote (non-loopback Host) browsers** (`gzip.remoteOnly: true`)
-to save local CPU; set `false` to also compress local. SSE streams, binary types
-(`image/*`, etc.), already-compressed responses (any `Content-Encoding`), `204/206/304` and
-small responses (`Content-Length < minBytes`) are never compressed. `gzip.enabled: false`
-turns it off completely.
-
----
-
-## 4. Implementation details
-
-### Architecture overview
-
-The plugin is a **Cordis dual-half package + bundle patch**:
-
-```
-dsh-remote/
-├── cordis.patch.yml   # bundle patch: inserts the `remote` row; swaps the directory picker backend
-├── lib/
-│   ├── index.js       # host half: gate, sessions, rate limiting, roles, trustProxy, /auth/* routes
-│   ├── store.js       # account store (scrypt hashes, protected flag, TOTP state, backup-code hashes)
-│   ├── totp.js        # RFC 6238 TOTP / base32 / otpauth URI / backup codes (zero-dependency)
-│   ├── login-page.js  # self-contained login page (password → code → bind guide, incl. QR), zh/en
-│   └── client.js      # browser half: re-login overlay, Settings "Auth & Accounts" page, log out
-└── package.json       # dsh.bundle.patch + dsh.client declaration + ./client export
-```
-
-- After install, `dsh plugin` appends `@xgone/dsh-remote` to `dsh.profile.bundles`; the patch
-  composes at boot;
-- The host half activates via `inject: ["webServer"]`; the browser half is picked up by the
-  client module system into `window.__DSH_BOOT__` and mounts into `settings.section` / overlays.
-
-### 4.1 The gate (`lib/index.js`)
-
-DSH's `webServer` routing model is "exact table → prefix table → fallback" with **no middleware
-hook**. The plugin implements a full gate by **wrapping the route-registration methods and
-in-place wrapping of already-registered entries**:
-
-- Wraps `register` / `registerUpgrade` / `registerFallback`, and wraps every **already-registered**
-  entry in `webServer.exact / prefixes / upgrades` and the `fallback` (a `Symbol` marker prevents
-  double wrapping; a `WeakMap` keeps the originals so the unload can restore them);
-- Wrapped HTTP handlers: `/auth/*` passes through → without a valid session, page requests get the
-  login page and everything else gets 403 → after passing, **Host/Origin are normalized before
-  handing off** (see `trustProxy`);
-- WebSocket upgrade handshake: no cookie → the socket is destroyed;
-- Role gating: non-admin sessions first read the RPC envelope (up to 16 MiB), look up the `method`
-  in a deny table and 403 on a hit; allowed requests are handed down with a replayable body
-  (`Readable` + `Proxy`); admin requests have zero overhead.
-
-### 4.2 Sessions and credentials
-
-- **Session cookie**: `v1.<base64url payload>.<HMAC-SHA256 sig>`, payload is
-  `{sub, role, iat, exp}`; verification recomputes the signature and compares in constant time,
-  and the account must still exist (deleting it invalidates the session);
-- **MFA challenge token**: `mfa.<payload>.<sig>`, 5-minute validity, single-use (a consumed-nonce
-  set prevents replay);
-- **Password**: scrypt (`node:crypto`), verified asynchronously at sign-in with constant-time
-  comparison;
-- **Rate limiting**: in-memory table keyed by `IP:username`; the password step and the MFA step
-  use different keys (a failed MFA count is not cleared by a successful password step).
-
-### 4.3 Remote access (`trustProxy`)
-
-DSH's built-in browser trust fence (`dsh-client-connection`) checks `Host` (loopback or
-`trustedHosts`), that `Origin` matches the Host, that `sec-fetch-site` is not cross-site, and
-**privileged methods** (`host.pickDirectory`, `settings.*`, `credentials.*`, …) are hard-coded to
-loopback. After authentication the plugin normalizes the request's `Host`/`Origin` to
-`127.0.0.1:<port>` (preserving the original scheme) before handing it down — the fence sees
-loopback and privileged methods work for external browsers. Unauthenticated requests are still
-403'd by the gate, so the fence's DNS-rebinding semantics are no longer needed behind the cookie.
-
-### 4.3.1 New-dsh adaptation: minting `dsh-auth-*` session cookies (>= 0.1.2-alpha, issue #10)
-
-Since dsh `0.1.2-alpha`, `client-connection` additionally requires a persistent signed cookie
-**bound to the request Host** (`dsh-auth-<sha256(Host)>`, HMAC-SHA256, keyed by the
-`client-connection/browser-session` record in `$DSH_HOME/.credentials.yaml`) on `/api`, the
-stream WebSocket (`/api/remote.mux`) and index.html alike. That cookie is only minted by dsh's
-own `?token=<launch token>` exchange, which a remote browser can never reach — and it can never
-hold a cookie bound to `127.0.0.1:<port>` — so after login every `/api` call returned 401.
-
-This plugin adapts (on by default, zero configuration):
-
-- **On login / MFA / bootstrap success** it reads client-connection's persisted signing secret
-  and mints two `dsh-auth-*` cookies with the exact core algorithm: one bound to the
-  **normalized loopback authority** (used by `/api` and the stream WebSocket), one bound to the
-  **original public Host** (used by the index/static fallback path);
-- **Self-heal**: every gated request verifies that a live cookie for the relevant authority is
-  present (including core-minted ones) and appends a fresh mint onto the current response when
-  not — sessions created before this fix, or whose cookies were evicted, repair themselves on
-  the next request without re-login;
-- **Old-dsh compatibility**: when the `client-connection/browser-session` credential record is
-  absent (or the runtime has no `credentials` service), minting stays off and behavior is
-  identical to 0.3.0;
-- **Browser-half RPC shape adaptation**: alpha renamed RPC endpoints to `namespace/method`
-  (slash) with a single `args` envelope field (`settings.describe` → `settings/describe`). The
-  client tries the new shape first, falls back to the dotted spelling on 404, and pins whichever
-  worked for the page — one bundle serves both rc and alpha; the host-half role gate likewise
-  normalizes slash method names before matching the dotted deny lists, so non-admin limits hold
-  on both generations.
-
-Configuration (rarely needed):
-
-```yaml
-browserAuth:
-  enabled: true          # minting master switch
-  cookieTtlSeconds: 0    # 0 = follow session.ttlSeconds (default 7d)
-```
-
-> A minted window must not exceed `client-connection`'s `cookieMaxAgeDays` (default 30); the
-> plugin already clamps to that bound. If you lower `cookieMaxAgeDays` in your deployment, lower
-> `cookieTtlSeconds` to match. Deployments running `trustProxy: false` with dsh's native
-> `--trusted-host <domain>` are covered too: the plugin then mints only the cookie bound to the
-> original public Host, and the fence is satisfied via `trustedHosts`.
-
-### 4.4 Storage (`lib/store.js`)
-
-`$DSH_HOME/auth/store.json` (0600, atomic writes):
-
-```jsonc
-{
-  "version": 1,
-  "secret": "<base64url 32B>",          // session/MFA token signing secret
-  "accounts": [{
-    "username": "admin",
-    "role": "admin",
-    "passwordHash": "scrypt$<salt>$<hash>",
-    "protected": true,                  // first account: cannot be removed or re-roled
-    "totp": { "secret": "<base32>", "verified": true, "createdAt": 0 },  // empty when not enabled
-    "backupCodes": [{ "hash": "<sha256>", "usedAt": 0 }],                // hashes only
-    "createdAt": 0, "updatedAt": 0, "lastLoginAt": 0
-  }]
-}
-```
-
-Migration: if an older store has no `protected` field, the account with the earliest `createdAt`
-is automatically marked protected and persisted.
-
-### 4.5 TOTP (`lib/totp.js`, zero-dependency)
-
-- base32 encode/decode (RFC 4648) and `otpauth://` URI construction;
-- TOTP = HMAC-SHA1(secret, 8-byte big-endian counter) dynamic truncation to 6 digits, 30-second
-  period; verification supports a ±window step; validated against the RFC 6238 SHA-1 appendix
-  vectors (T=0..5);
-- Backup codes: 10 unambiguous 8-character codes, stored as SHA-256 hashes, each usable once.
-
-### 4.6 Login page (`lib/login-page.js`)
-
-Rendered inline by the wrapped fallback for unauthenticated browsers — **zero external
-resources**. State machine: `password → (code | offer) → setup`. i18n: `zh` / `en`, selected at
-render time from the request's `Accept-Language`.
-
-- Password step → with MFA, moves to the code step (with a "valid for Ns" countdown and 6-digit
-  auto-submit);
-- Without MFA, shows the "bind two-factor" guide (skippable);
-- The bind step shows the QR code (`/auth/mfa/setup` returns an SVG data URL) + secret + otpauth +
-  backup codes + verify input; on success it redirects to `next`;
-- The form uses `novalidate` + manual JS validation (so hidden required controls never block
-  submission).
-
-### 4.7 Browser half (`lib/client.js`)
-
-Hand-written `window.__ModuleLoader__.load({id, factory})` format (same as official bundles, no
-bundler needed), mounted via `require("react")` / `react-dom/client`. All UI copy goes through a
-built-in zh/en `t()` table selected by `document.documentElement.lang`.
-
-- **Re-login overlay**: polls `/auth/me` (15 s + on focus); when unauthenticated and auth is
-  enabled, a full-screen login overlay covers the app (supports the MFA second step);
-- **Settings → Auth & Accounts** (`settings.section` slot with a user icon; CSS hides the shell's
-  default gear): status, MFA self-service, account card list (reset password / disable MFA /
-  remove), log out;
-- All data goes through `fetch("/auth/*")` (same-origin cookies), independent of the settings
-  domain (third-party code cannot register there).
-
-### 4.8 Directory picker swap (`cordis.patch.yml`)
-
-Patch rows **cannot be renamed** (a `name mismatch` is skipped), so the swap is "disable +
-insert":
-
-```yaml
-- id: directory-picker        # disable the auto picker (resolves to native on loopback and pops on the host)
-  disabled: true
-- insert:
-    - id: directory-picker-browse      # browse host backend (host.listDirectory / createDirectory)
-      name: '@deepseek-ai/dsh-host-directory-picker-browse'
-      config: { maxEntries: 1000 }
-    - id: directory-picker-browse-ui   # browser-side directory dialog
-      name: '@deepseek-ai/dsh-client-ui-directory-picker-browse'
-```
-
-### 4.9 Security model (threat analysis)
-
-| Attack surface | Defense |
-|---|---|
-| Unauthenticated `/api` / static pages / WebSocket | gate 403 / login page / handshake rejection |
-| Password brute force | scrypt + rate limiting (IP+username) |
-| Session forgery/tampering | HMAC signature + expiry + constant-time compare + account-existence check |
-| Session replay (MFA second step) | single-use nonce + 5-minute TTL |
-| Remote admin pre-registration | bootstrap loopback-only |
-| Deleting the only admin | protected account + last-admin protection |
-| Cross-site requests (CSRF) | HttpOnly + SameSite=lax; cross-site requests carry no cookie, so the gate 403s |
-| DNS rebinding | the auth layer takes over the fence semantics; unauthenticated requests never reach the fence |
-
----
-
-## 5. Remote deployment
-
-`dsh web` still refuses `--host 0.0.0.0`, so expose it through a reverse proxy (TLS
-termination + WebSocket forwarding):
+`dsh web` only listens on loopback — expose it through a reverse proxy (WebSocket forwarding
+required):
 
 ```nginx
 server {
@@ -559,45 +79,73 @@ server {
   location / {
     proxy_pass http://127.0.0.1:3080;
     proxy_http_version 1.1;
-    proxy_set_header Upgrade $http_upgrade;      # WebSocket (events.mux/host)
+    proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";
-    proxy_set_header Host $host;                 # preserve the external Host
+    proxy_set_header Host $host;
     proxy_set_header Origin $http_origin;
   }
 }
 ```
 
-The same applies to `ssh -R` tunnels, Tailscale, Frp, etc. For HTTPS deployments set
-`session.secure` to `true`.
+`ssh -R` tunnels, Tailscale, Frp, etc. work the same way. For HTTPS deployments also set
+`session.secure` to `true` in the config.
 
-## 6. Multi-account model (design notes)
+## Configuration
 
-- **Done**: multiple accounts + roles (admin/user/guest), centralized management, MFA, audit
-  fields (created/updated/last login);
-- **Not possible at plugin level**: per-user workspaces/sessions (multi-tenant data isolation) —
-  DSH core is single-tenant (`$DSH_HOME` is process-wide), so event streams, search, tasks, etc.
-  leak globally and cannot be isolated by a plugin;
-- **Recommended**: one profile instance per person (`dsh --profile alice --port 3081`) gives
-  natural data isolation; for a shared instance, use the role system.
+Edit the `config` of the `remote` row in `~/.dsh/profiles/web/cordis.patch.yml`. Common options:
 
-## 7. Endpoint reference
+```yaml
+- id: remote
+  config:
+    enabled: true          # false = disable the gate (escape hatch if locked out)
+    session:
+      secure: false        # set true for HTTPS deployments
+    adminOnly: true        # false = enable multi-role (admin/user/guest) account management
+    bootstrap:             # optional: provision the first admin (only while the store is empty)
+      username: admin
+      password: 'pick-a-strong-password'
+```
 
-| Method | Path | Description |
-|---|---|---|
-| POST | `/auth/login` | Sign in; returns `{mfaRequired, mfaToken}` when MFA is on (no cookie issued) |
-| POST | `/auth/mfa/login` | Second step: `{mfaToken, code}` (TOTP or backup code) |
-| POST | `/auth/logout` | Clear the cookie |
-| GET | `/auth/me` | `{authEnabled, bootstrap, authenticated, username, role, mfa, adminOnly}` |
-| POST | `/auth/bootstrap` | First-admin bootstrap (loopback only, empty store only) |
-| POST | `/auth/mfa/setup` | Generate secret + otpauth + QR + backup codes (pending state) |
-| POST | `/auth/mfa/verify` | Confirm the pending setup with a TOTP code |
-| POST | `/auth/mfa/disable` | Disable MFA for the current account (needs password + valid code/backup code) |
-| POST | `/auth/accounts` | Admin: `{action: list\|upsert\|remove\|disable-mfa, ...}` |
+Defaults work out of the box; the full option set (session, MFA, rate limit, gzip, file panel,
+…) is documented in [docs/REFERENCE.md](docs/REFERENCE.md#13-full-configuration-reference).
 
-## 8. Limitations and escape hatches
+### Headless servers (no local browser)
 
-- HMR is disabled on the web surface — **restart `dsh web`** after config changes;
-- Escape hatch: set `enabled: false` and restart to disable the gate; or delete
-  `$DSH_HOME/auth/store.json` to re-enter bootstrap mode;
-- Restore the native directory picker: see section 4.8 for the patch snippet (invert the
-  `disabled` flags).
+Add the `bootstrap` config block (above) to `cordis.patch.yml` and restart — the first admin is
+provisioned at startup, equivalent to the local bootstrap. After the first login, remove the
+plaintext password and bind MFA.
+
+## FAQ
+
+| Symptom | Fix |
+|---|---|
+| No login page after install | Restart `dsh web`; confirm `@xgone/dsh-remote` is in the bundles list |
+| 403 when creating the admin | The first admin is loopback-only: use a local browser, or reach `127.0.0.1` via `ssh -L`; on headless servers use the `bootstrap` config |
+| Locked out | Set `enabled: false` in `cordis.patch.yml` and restart; or delete `$DSH_HOME/auth/store.json` to re-enter bootstrap mode |
+| Lost MFA / phone | As admin: Settings → Auth & Accounts → that account → Disable MFA |
+| File panel reports `outside-roots` | Settings → Auth & Accounts → Allowed directories: add the directory (applies immediately, no restart) |
+| After a dsh upgrade every `/api` call returns 401 despite a successful login | Upgrade this plugin (≥ 0.3.1) and **sign in once more** — see the [CHANGELOG](CHANGELOG.md) |
+| Settings pages misbehave / popups return after a dsh upgrade | Upgrade this plugin first — compatibility fixes for new DSH versions ship built-in, see the [CHANGELOG](CHANGELOG.md) |
+
+## Documentation
+
+- **Changelog**: [CHANGELOG.md](CHANGELOG.md) — changes per version, including "after a dsh
+  upgrade" compatibility fixes;
+- **Technical reference**: [docs/REFERENCE.md](docs/REFERENCE.md) — architecture, internals,
+  full configuration and endpoint reference (for AI agents and contributors).
+
+## Uninstall
+
+```sh
+dsh plugin --profile web remove @xgone/dsh-remote
+```
+
+After restarting `dsh web` the gate is gone; account data is kept in
+`$DSH_HOME/auth/store.json` (delete the file for a complete reset).
+
+## Known limitations
+
+- Config changes require restarting `dsh web` (HMR is disabled on the web surface);
+- All accounts share the same workspaces and sessions — the DSH core is single-tenant and a
+  plugin cannot isolate data; use one profile instance per person
+  (`dsh --profile alice --port 3081`) when isolation matters.

--- a/README.md
+++ b/README.md
@@ -5,9 +5,8 @@
 
 [English](README.en.md) | **中文**
 
-**让 DeepSeek Harness 可以被安全地远程访问**：在 `dsh web` 前增加完整的账号密码认证 + MFA
-（两步验证）门禁，并打通外网部署所需的全部环节——外部浏览器登录后即可使用完整功能（含工作区
-选择、添加工作区等），全程不会在宿主机上弹出任何原生窗口。
+**让 DeepSeek Harness 可以被安全地远程访问**：在 `dsh web` 前增加账号密码 + MFA（两步验证）
+门禁，外网浏览器登录后即可使用完整功能——全程不在宿主机上弹出任何原生窗口。
 
 ### 界面预览
 
@@ -15,466 +14,51 @@
 |:---:|:---:|
 | ![登录页](docs/login-zh.png) | ![账号管理设置页](docs/settings-zh.png) |
 
----
+## 功能特性
 
-## 一、已实现的功能（用户视角）
+- **远程访问**：经反向代理（nginx / ssh 隧道 / Tailscale / Frp 等）暴露后，外部浏览器登录即用
+  全部功能；选择 / 新建工作区是浏览器内的目录对话框，不会在宿主机弹窗；WebSocket 事件流全通。
+- **登录门禁**：未登录访问任何路径都是登录页，`/api` 与 WebSocket 全部要求有效会话；密码
+  scrypt 加密存储、登录失败限速、首个管理员仅限本机创建。
+- **MFA 两步验证（TOTP）**：兼容 Google Authenticator / 1Password / Authy 等标准认证器，扫码
+  绑定 + 10 个一次性备用码；忘记动态码时管理员可代为关闭。
+- **远程文件面板**：点击文件路径不再在宿主机桌面打开，而是在右侧边栏预览（Markdown / 图片 /
+  PDF / 文本 / 目录浏览），默认仅允许 DSH 主目录与工作目录，可在设置页添加允许的目录。
+- **多账号（可选）**：默认仅管理员；关闭 `adminOnly` 后支持 admin / user / guest 三级权限。
+- **界面跟随 DSH**：浅色 / 深色主题自动跟随，中英双语跟随 DSH 应用语言。
+- **远程访问更快**：响应自动 gzip 压缩（默认仅远程），静态资源配合边缘缓存。
 
-### 1. 远程访问 dsh
+## 快速开始
 
-- **外网/局域网可用**：经反向代理（nginx / ssh 隧道 / Tailscale / Frp 等）暴露后，外部浏览器
-  登录即可使用全部功能。DSH 自带的 `/api` 信任围栏把 `host.pickDirectory`、`settings.*`、
-  `credentials.*` 等特权方法硬编码钉死在 loopback（官方注明"直到真正的认证层出现"）——本插件
-  就是那个认证层，认证通过后自动放行。
-- **工作区/添加工作区不弹宿主窗口**：DSH 默认的目录选择器在 loopback 部署下会调用宿主机原生
-  OS 选择框（远程用户看不到）。本插件把选择器替换为 **browse 后端**——选择/新建工作区变成
-  **浏览器内的目录对话框**（双栏目录视图 + 面包屑 + 新建文件夹）。
-- **WebSocket 全通**：事件下行流（`events.mux` / `events.host`）经认证后正常建立。
-
-### 2. 账号密码验证
-
-- **完整登录门禁**：未登录访问任何路径都得到自包含的登录页；`/api` 与 WebSocket 全部要求有效
-  会话 Cookie。
-- **安全的会话**：HMAC-SHA256 签名的 HttpOnly Cookie（可配过期时间、Secure、SameSite）；
-  签名密钥随机生成并持久化（重启后会话仍有效）。
-- **密码安全存储**：scrypt 哈希（`N=16384,r=8,p=1`）+ 常量时间比较，绝不落盘明文。
-- **防暴力破解**：登录失败按「IP + 用户名」限速（默认 15 分钟窗口内 5 次）。
-- **首次引导**：无账号时登录页提供"创建首个管理员"，仅本机（loopback）可提交，防止远程抢先注册。
-- **首个账号受保护**：根账号不可删除、不可改角色，只能重置密码（防止误删唯一管理员锁死）。
-- **仅管理员模式（默认）**：运行时禁止新建账号、所有账号强制 admin 角色、设置页隐藏"添加账号"。
-- **多角色可选**：关闭 `adminOnly` 后可启用 `admin` / `user` / `guest` 三层方法级权限。
-
-### 3. MFA 两步验证（TOTP）
-
-- **兼容标准认证器**：Google Authenticator、1Password、Authy 等（RFC 6238，6 位 / 30 秒）。
-- **扫码绑定**：开启时展示二维码（SVG，实测可扫）+ 手动密钥 + otpauth 链接 + 10 个一次性备用码
-  （备用码仅存 SHA-256 哈希）。
-- **登录实时验证**：登录页与重登浮层显示"有效剩余 N 秒"倒计时，输入满 6 位数字**自动验证**
-  （备用码含字母，仍手动确认）。
-- **管理员恢复**：管理员可用自己的密码为任意账号禁用 MFA（找回路径）。
-
-### 4. 体验细节
-
-- 登录页即完整认证面：密码 → 动态码 / 就地绑定引导（含二维码）；
-- 会话过期时 SPA 内出现全屏重登浮层，输入自动验证；
-- 设置 → 登录与账号：MFA 自服务（开启/关闭）、账号列表（卡片式）、重置密码、退出登录按钮。
-
-### 5. 浅色 / 深色主题跟随
-
-插件全部界面（登录页、MFA 引导、重登浮层、设置页、远程文件侧栏）通过 DSH 官方设计令牌（`--dsw-alias-*`）取色，
-自动跟随 DSH 的外观设置（浅色 / 深色 / 跟随系统）切换，无需插件自身的主题配置。
-
-### 6. 多语言支持（`zh` / `en`）
-
-插件的全部界面——登录页、MFA 绑定引导、重登浮层、设置页（登录与账号）——均提供中英双语，跟随 **DSH 应用语言设置**（Settings → General → Language）：
-
-- **登录页**：服务端渲染，优先读 `$DSH_HOME/settings.yaml` 的 `locale.preference`（即 DSH 应用语言），未设置时回落浏览器 `Accept-Language`；
-- **应用内界面**：接入官方 `@deepseek-ai/dsh-client-locale` 服务（`ctx.locale`），注册插件的 zh/en 字典并实时跟随语言切换——切换语言时设置页与浮层即时更新，无需刷新。
-
-**远程浏览器语言持久化**：DSH 出于安全设计把整个设置面钉死在 loopback（本机）——远程浏览器的设置读写只进内存，语言偏好在 DSH 原生机制下刷新即丢。本插件作为远程部署的认证层，为非 loopback 浏览器接管了语言配置的双向通道：
-
-- **读**：启动时经标准 `settings.describe` RPC 取回持久化偏好并应用到界面（登录页也在服务端读同一份偏好）；
-- **写**：语言切换经标准 `settings.mutate` RPC 落盘 `settings.yaml`，跨浏览器、跨设备一致。
-
-本机（`127.0.0.1` / `localhost`）访问完全走 DSH 原生 host-backed 路径，插件不做任何介入。两条通道都基于 DSH UI 自身使用的标准 RPC 信封，不魔改任何宿主内部状态。
-
----
-
-## 二、安装引导（Installation）
-
-### 0. 前置条件
-
-- 已安装 DeepSeek Harness 并可运行 `dsh web`（默认端口 3080）；
-- 已初始化 `web` profile（首次运行 `dsh web` 会自动初始化）；
-- 系统 PATH 中有 `pnpm`（`dsh plugin` 命令需要它来管理 profile 的插件）。
-
-### 1. 安装插件包
-
-**NPM 安装（推荐）**——插件已发布到 npm registry，一行命令即可：
+### 1. 安装
 
 ```sh
 dsh plugin --profile web add @xgone/dsh-remote
 ```
 
-> - 包主页：https://www.npmjs.com/package/@xgone/dsh-remote
-> - 固定版本：`dsh plugin --profile web add @xgone/dsh-remote@0.1.0`
+### 2. 重启 `dsh web`
 
-其他安装方式：
-
-```sh
-# 从公开 Git 仓库安装
-dsh plugin --profile web add git@github.com:xgone/dsh-remote.git
-
-# 本地源码目录（开发/自用，路径替换为你实际的源码位置）
-dsh plugin --profile web add ~/path/to/dsh-remote
-```
-
-`dsh plugin` 会做三件事：
-
-1. 在 `~/.dsh/profiles/web/` 下用 pnpm 安装该包（输出 `+ @xgone/dsh-remote` 即成功）；
-2. 自动把 `@xgone/dsh-remote` 追加到 profile 的 `dsh.profile.bundles`（因为包声明了
-   `dsh.bundle.patch`）——无需手动改配置；
-3. 插件随下次启动的 composition 生效。
-
-### 2. 确认安装结果
+补丁不支持热重载，必须重启才生效：
 
 ```sh
-# bundles 列表中应出现 @xgone/dsh-remote
-python3 -c "import json; print(json.load(open('$HOME/.dsh/profiles/web/package.json'))['dsh']['profile']['bundles'])"
-# 期望输出类似：['@deepseek-ai/dsh-base', '@deepseek-ai/dsh-web-app', '@xgone/dsh-remote']
-```
-
-### 3. 重启 `dsh web`
-
-Web 表面目前禁用 HMR，补丁热重载不可用，**必须重启**才生效：
-
-```sh
-# 结束当前 dsh web 进程后重新启动（或直接重启你的启动方式）
 dsh web
 ```
 
-### 4. 首次启动：创建管理员
+### 3. 创建首个管理员
 
-重启后，浏览器打开 `http://127.0.0.1:3080`：
+在本机浏览器打开 `http://127.0.0.1:3080`，登录页处于引导模式：输入用户名和密码（至少 6 位）
+创建首个管理员，创建成功即登录。
 
-1. 未登录访问会看到**登录页**（自包含页面，非 SPA）；
-2. 由于还没有任何账号，登录页处于**引导模式**：标题为"创建首个管理员账号"；
-3. 输入用户名和密码（至少 6 位），点击创建——**仅限本机（loopback）提交**，防止远程抢先注册；
-4. 创建成功即登录（签发会话 Cookie），随后可正常使用。
+> 服务器没有本地浏览器？见下方 [无浏览器服务器](#无浏览器服务器headless)。
 
-> 验证：`curl http://127.0.0.1:3080/auth/me` 应返回
-> `{"authEnabled":true,"bootstrap":false,"authenticated":true,...}`。
+### 4. 绑定 MFA（推荐）
 
-### 5. 绑定 MFA（推荐）
+进入 **设置 → 登录与账号 → 双重验证 (MFA) → 启用**，用认证器扫码并输入 6 位动态码即可。
+**请先保存页面上的 10 个备用码。**
 
-登录后进入 **设置 → 登录与账号 → 双重验证 (MFA) → 启用双重验证**：
+### 5. 远程访问
 
-1. 页面展示**二维码**（Google Authenticator / 1Password / Authy 扫码即可添加）；
-2. 同时展示手动密钥、otpauth 链接与 **10 个一次性备用码**——请先保存备用码；
-3. 在认证器中输入当前 6 位动态码 → 自动验证并启用；
-4. 之后每次登录都需 密码 + 动态码（或备用码）。
-
-> 也可以不进入设置页：登录页在密码验证通过后（未开启 MFA 时）会直接给出"绑定双重验证"引导。
-
-### 6. 验证安装
-
-- 未登录时访问任意路径 → 登录页；直接调用 `/api` → 403；
-- 登录后 `/api`、WebSocket 事件流、工作区选择（浏览器内目录对话框）均正常；
-- 会话过期（或退出登录）后回到登录页。
-
-### 7. 卸载
-
-```sh
-dsh plugin --profile web remove @xgone/dsh-remote
-```
-
-`dsh plugin` 会执行 pnpm remove，并自动把该包从 `dsh.profile.bundles` 移除；
-重启 `dsh web` 后门禁即消失。已创建的 `$DSH_HOME/auth/store.json` 与账号数据会保留
-（如需彻底清除可手动删除该文件）。
-
-### 8. 常见问题
-
-| 现象 | 处理 |
-|---|---|
-| 安装后无登录页 | 未重启：执行 `dsh web` 重启；或 bundles 列表里没有 `@xgone/dsh-remote`（重跑 `dsh plugin --profile web add ...`） |
-| 登录页提交无反应 | 确认表单已填用户名/密码；浏览器控制台的 `content-script.js` 报错是扩展噪音，可忽略 |
-| 创建管理员时报 403 | bootstrap 仅限 loopback：请在本机浏览器操作，或经 `ssh -L` 后访问 `127.0.0.1`；无本地浏览器的服务器请用下方 `bootstrap` 配置预置管理员 |
-| 被锁在门外（配置出错） | 编辑 `cordis.patch.yml` 设 `enabled: false` 重启；或删除 `$DSH_HOME/auth/store.json` 重新引导 |
-| 忘记 MFA / 丢手机 | 管理员登录后在 设置 → 登录与账号 → 该账号行 → 禁用 MFA（需管理员密码） |
-| 远程访问时「设置 → 插件」配置页空白 | v0.1.5+ 已内置修复：DSH 对远程浏览器把所有设置 scope 切成 memory 模式（读写在客户端被丢弃），插件启动时自动解除该限制并触发一次全量刷新，配置卡片远程可读可写；原始 settings.yaml 文档编辑器仍保持仅限本机（设计如此） |
-| 远程刷新后反复弹出「内测声明」 | v0.1.6+ 已内置修复（已确认用户）：DSH 的欢迎弹窗确认态 `WelcomeNoticeStore` 对远程走 memory 模式，不读已持久化的确认；插件用官方 `settings.describe` RPC 读 `ui-onboarding.welcomeNoticeVersion`，有值时经官方 `store.update` 置 `acknowledged=true`，`WelcomeNotice` 即自动收场不再弹。全程只用官方 slots/store/RPC，不重写 DSH 内部方法、不改 persistence。纯远程首次用户（从无确认）维持原行为 |
-| 远程打开「设置 → 模型」提示"加载提供方目录失败: settings are unavailable in this browser" | v0.2.6+ 已内置修复：DSH 升级后所有设置读取改经共享的 `SettingsDescribeMirror`（远程构造为 memory 模式，`view` 恒为 undefined），Models 页因此抛错；插件用官方 `settings.describe` RPC 读取设置文档，经官方 `ctx.settingsScope.describe()` 拿到 mirror，再用官方 `store.set` 注入 `view`，Models 目录远程正常加载。全程只用官方 RPC/服务/store API，不重写 DSH 方法、不改 persistence |
-| 升级到 dsh 0.1.2-alpha+ 后，远程登录成功但所有 `/api` 返回 401（index.html 也可能 401） | v0.3.1+ 已内置修复（issue #10）：新版 dsh 的 `client-connection` 额外要求绑定请求 Host 的 `dsh-auth-*` 持久化签名 Cookie，远程浏览器拿不到也无法自行铸造；插件现在在登录时用核心同款算法铸造并下发（绑定归一化 loopback 与原始公网 Host 各一枚），并在门禁层自愈补发——**升级插件后重新登录一次即可**，升级前创建的旧会话会在下一次请求时自动修复 |
-
-### 9. 无浏览器服务器（headless / Linux）安装
-
-服务器没有本地浏览器时，UI 的「创建管理员」引导（仅限 loopback）无法使用。用 `bootstrap`
-配置节在启动时直接预置首个管理员（等价于 loopback 引导：同样受保护、管理员角色、scrypt 哈希）：
-
-```sh
-dsh plugin --profile web add @xgone/dsh-remote
-# 编辑 ~/.dsh/profiles/web/cordis.patch.yml，给 remote 行加 config:
-```
-
-```yaml
-- id: remote
-  config:
-    enabled: true
-    bootstrap:
-      username: admin          # 首次启动时创建（仅当账号库为空）
-      password: '换成一个强密码'
-```
-
-要点：
-
-- **幂等**：账号库非空后该配置被忽略（日志提示移除凭据），不会重复创建、不会覆盖已有密码；
-- 密码至少 6 位（与 UI 引导一致），违规会在启动时报错并中止；
-- 首账号与 UI 引导一致：`protected: true`（不可删除/降级，仅可重置密码）；
-- 建议首次登录后从 `cordis.patch.yml` 移除该配置节（保留也无风险——账号存在后即失效），
-  之后可在 设置 → 登录与账号 绑定 MFA；
-- 反向代理部署只需再加 `trustProxy: true`（默认已开启）。
-
-## 三、配置（`cordis.patch.yml`）
-
-```yaml
-# ~/.dsh/profiles/web/cordis.patch.yml（覆盖 remote 行的整份 config，缺省键回落到默认值）
-- id: remote
-  config:
-    enabled: true
-    accounts: []            # 种子账号（明文密码启动时转 scrypt 哈希；或直接给 scrypt$<salt>$<hash>）
-    secret: ''              # 空 = 自动生成并持久化
-    session:
-      cookieName: dsh_session
-      ttlSeconds: 604800    # 7 天
-      secure: false         # HTTPS 部署建议 true
-      sameSite: lax
-    enforceRoles: true      # admin/user/guest 方法级权限
-    adminOnly: true         # 仅管理员账号（默认）
-    trustProxy: true        # 已认证请求归一化 Host/Origin，放行外部访问（默认）
-    bootstrap:
-      username: admin       # 可选：无浏览器服务器预置首个管理员（账号库为空时生效）
-      password: '...'
-    mfa:
-      enabled: true
-      issuer: DeepSeek Harness
-      window: 1             # ±1 个 30 秒步长
-      backupCodes: 10
-    rateLimit:
-      maxAttempts: 5
-      windowMs: 900000
-    gzip:
-      enabled: true          # 响应 gzip 压缩总开关（默认开）
-      remoteOnly: true       # 仅对远程（非 loopback Host）请求压缩；false 则本地也压
-      minBytes: 1024         # 已知 Content-Length 小于此字节数的响应不压缩
-    files:
-      enabled: true          # 远程文件显示（/auth/file）总开关（默认开）
-      maxListing: 500        # 目录索引每页最多渲染的条目数
-    browserAuth:
-      enabled: true          # dsh ≥ 0.1.2-alpha 的 dsh-auth-* Cookie 铸造（默认开，见「3.1」）
-      cookieTtlSeconds: 0    # 0 = 跟随 session.ttlSeconds；上限为 client-connection.cookieMaxAgeDays
-```
-
-> **角色门禁只作用于 client-request**：`/api/respond`（浏览器应答宿主的 server-request：审批、提问、
-> 工具结果等）的封包没有 `method` 字段，早期实现会把它们误判为未知方法而拒绝，导致宿主挂起的流式
-> 请求失败、WebSocket 重连、工作区/会话基线被重置。现在仅对 `type: "client-request"` 封包按方法做
-> 角色判定，其余 wire 协议消息一律放行。被拒绝的 client-request 返回符合 RPC 契约的
-> `server-response` 错误封包（回显 rpcId），浏览器按业务错误处理而不是传输故障。
-
-> **Windows 提示**：默认允许读取的目录是 DSH 主目录与 dsh 进程工作目录（通常是 profile 目录），而工作区
-> 文件常在其他盘符路径下。当面板提示 `outside-roots` 时，用管理员账号打开 **Settings → 登录与账号 →
-> 允许的目录**，把工作区所在目录添加进去即可（如 `E:\CODE`；输入框里正斜杠 `E:/CODE` 或双反斜杠
-> `E:\\CODE` 两种写法都支持），**即时生效，无需改配置文件、无需重启**。
-
-关闭认证：`enabled: false`。
-
-**远程文件显示**：DSH 的 Web UI 点击文件路径时走 `host.openPath` RPC，把路径交给**宿主机**桌面
-的默认应用打开——远程浏览器用户完全看不到。本插件在远程（非 loopback）浏览器上拦截该 RPC，改为在
-**右侧边栏面板**中显示（`/auth/file` 由宿主机流式返回，参考 Claude Desktop 的交互）：
-- Markdown 使用界面同款渲染器排版，图片 / PDF / 视频内联显示，文本与代码等宽预览，目录可逐级点击浏览
-- 支持同时打开**多个面板**，自动上下等分分割；每个面板右上角有独立的「放大」（占满整个侧栏，可还原）
-  与「关闭」按钮
-- 面板头部显示文件名与完整路径；侧栏左缘可拖拽调整宽度；Esc 关闭最上方 / 放大的面板
-- 不可预览的二进制提供下载与新标签页兜底
-
-DSH 原生的右侧 details 列（会话详情，单槽位）不受影响，本侧栏以覆盖层形式与其并存。**默认能看哪些文件？**
-只有 DSH 主目录与 dsh 进程工作目录内的文件；范围外的路径面板会提示
-`cannot display file (outside-roots)`。所有读取都做 realpath 校验，符号链接逃逸与 `..` 穿越一律拒绝；
-本机（loopback）访问保持 DSH 原生行为不变。`files.enabled: false` 可完全关闭。
-
-> **如何允许查看其他目录的文件（在设置页操作，不需要改配置文件）**
->
-> 1. 用**管理员**账号登录，打开 **Settings → 登录与账号 → 允许的目录**；
-> 2. 点「**选择目录**」在宿主机上直接挑一个目录，或在输入框里粘贴绝对路径，再点「**添加**」；
-> 3. 添加**立即生效，无需重启**——回到会话里重新点一下刚才的文件路径即可正常显示；
-> 4. 不再需要时，点该目录条目右侧的「删除」即可收回访问权限。
->
-> 添加的目录保存在 `$DSH_HOME/dsh-remote-files.json`（0600，原子写入），重启后依然有效；「配置文件提供的
-> 根目录」会以只读形式一并列出，但不受设置页管理。旧配置项 `files.roots` 仍然兼容生效（同样只读展示），
-> **新增目录请一律使用设置页**。面板被拒绝时显示的 `allowedRoots` 提示，会直接指向这个设置页。
-
-**响应 gzip 压缩**：插件会为**认证后**的可压缩响应（HTML / CSS / JS / JSON / SVG / manifest 等）自动
-gzip 压缩，显著减小远程访问时大历史会话与大型 bundle 的传输体积；并给带 rev 的哈希静态资源
-加 `Cache-Control: immutable` 与 `CDN-Cache-Control` 以配合 Cloudflare 等边缘缓存。默认**仅对
-远程（非 loopback）浏览器压缩**（`gzip.remoteOnly: true`），本机直连不压缩省 CPU；需要本地也
-压缩可设 `false`。SSE 事件流、二进制类型（`image/*` 等）、已压缩响应（带 `Content-Encoding`）、
-`204/206/304` 与过小的响应（`Content-Length < minBytes`）不会被压缩。`gzip.enabled: false` 可
-完全关闭。
-
----
-
-## 四、代码层面的实现
-
-### 架构总览
-
-插件是 **Cordis 双半区包 + bundle 补丁**：
-
-```
-dsh-remote/
-├── cordis.patch.yml   # bundle 补丁：插入 remote 行；替换目录选择器后端
-├── lib/
-│   ├── index.js       # 宿主半区：门禁、会话、限速、角色、trustProxy、/auth/* 路由
-│   ├── store.js       # 账号存储（scrypt 哈希、受保护标记、TOTP 状态、备用码哈希）
-│   ├── totp.js        # RFC 6238 TOTP / base32 / otpauth URI / 备用码（零依赖）
-│   ├── login-page.js  # 自包含登录页（密码 → 动态码 → 绑定引导，含二维码）
-│   └── client.js      # 浏览器半区：重登浮层、设置页「登录与账号」、退出按钮
-└── package.json       # dsh.bundle.patch + dsh.client 声明 + ./client 导出
-```
-
-- 安装后 `dsh plugin` 自动把 `@xgone/dsh-remote` 追加进 `dsh.profile.bundles`，补丁随 composition 应用；
-- 宿主半区以 `inject: ["webServer"]` 激活，浏览器半区由客户端模块系统扫描进
-  `window.__DSH_BOOT__` 并挂到 `settings.section` / 覆盖层。
-
-### 1. 门禁（`lib/index.js`）
-
-DSH 的 `webServer` 路由模型是"精确表 → 前缀表 → fallback"，**没有中间件钩子**。插件通过
-**包装路由注册方法 + 就地包装已注册表项**实现全量门禁：
-
-- 包装 `register` / `registerUpgrade` / `registerFallback` 三个方法，并对
-  `webServer.exact / prefixes / upgrades` 表与 `fallback` 中**已注册**的每一项逐个包装（用
-  `Symbol` 标记避免重复包装，`WeakMap` 记录原始处理器以便卸载还原）；
-- 包装后的 HTTP 处理器：`/auth/*` 放行 → 无有效会话则页面请求返回登录页、其余 403 →
-  通过后**先归一化 Host/Origin 再交给下层**（见 `trustProxy`）；
-- WebSocket 升级握手：无 Cookie 直接销毁 socket；
-- 角色门禁：非 admin 会话先读取 RPC 信封（上限 16 MiB）按 `method` 查禁止表，命中 403，
-  放行时用可重放请求体（`Readable` + `Proxy`）交给下层，admin 零开销。
-
-### 2. 会话与口令
-
-- **会话 Cookie**：`v1.<base64url payload>.<HMAC-SHA256 sig>`，payload 含
-  `{sub, role, iat, exp}`；验证时重算签名并常量时间比较，且账号必须仍存在（删除即失效）；
-- **MFA 挑战令牌**：`mfa.<payload>.<sig>`，5 分钟有效、一次性（nonce 消费集合防重放）；
-- **口令**：scrypt（node:crypto），登录时异步验证 + 常量时间比较；
-- **限速**：内存表按「IP:username」计数，密码步骤与 MFA 步骤使用不同键（MFA 失败计数不会被
-  成功密码步骤清掉）。
-
-### 3. 外网放行（`trustProxy`）
-
-DSH 内置的浏览器信任围栏（`dsh-client-connection`）校验 `Host`（loopback 或 `trustedHosts`）、
-`Origin` 与 Host 一致、`sec-fetch-site` 非 cross-site，且**特权方法**（`host.pickDirectory`、
-`settings.*`、`credentials.*` 等）被硬编码钉在 loopback。插件在认证通过后把请求的
-`Host`/`Origin` 归一化为 `127.0.0.1:<端口>`（保留原 scheme）再交给下层——围栏判定为 loopback，
-特权方法对外部浏览器放行。未认证请求仍被门禁 403，围栏的 DNS-rebinding 语义在 Cookie 之后不再
-需要。
-
-### 3.1 新版 dsh 适配：`dsh-auth-*` 会话 Cookie 铸造（≥ 0.1.2-alpha，issue #10）
-
-从 dsh `0.1.2-alpha` 起，`client-connection` 在围栏之外还要求一个**绑定请求 Host** 的持久化签名
-Cookie（`dsh-auth-<sha256(Host)>`，HMAC-SHA256，密钥保存在 `$DSH_HOME/.credentials.yaml` 的
-`client-connection/browser-session` 记录里）：`/api`、流式 WebSocket（`/api/remote.mux`）与
-index.html 都要校验。这个 Cookie 只能由 dsh 自己的 `?token=<启动令牌>` 流程铸造，而远程浏览器
-既拿不到启动令牌，也永远不可能持有绑定 `127.0.0.1:<端口>` 的 Cookie——登录后所有 `/api` 全部
-401。
-
-本插件的适配（默认开启，无需配置）：
-
-- **登录 / MFA / 引导成功时**，插件读取 client-connection 的持久化签名密钥，用与核心完全相同的
-  算法铸造并下发两个 `dsh-auth-*` Cookie：一个绑定**归一化后的 loopback authority**（供 `/api`
-  与 WebSocket 使用），一个绑定**原始公网 Host**（供 index.html / 静态回退路径使用）；
-- **自愈补发**：每个经过门禁的请求都会校验 Cookie 是否在位且有效（包括核心自己铸造的），缺失或
-  失效时在**当前响应**上补发——升级前创建的旧会话、被浏览器清理过 Cookie 的会话，下一次请求即自动
-  修复，无需重新登录；
-- **旧版 dsh 兼容**：读不到 `client-connection/browser-session` 凭证记录（或运行时没有
-  `credentials` 服务）时，铸造逻辑自动关闭，行为与 0.3.0 完全一致；
-- **浏览器半区 RPC 自适应**：alpha 起 RPC endpoint 改名 `namespace/method`（斜杠）且信封收窄为
-  单一 `args` 字段（`settings.describe` → `settings/describe`）。客户端调用先试新形状、404 时回落
-  旧点号形状并按页面缓存，同一份 bundle 同时服务 rc 与 alpha；服务端角色门禁也把斜杠方法名归一化
-  后再匹配点号拒绝表，非管理员限制在两代 dsh 上同样生效。
-
-配置项（通常无需改动）：
-
-```yaml
-browserAuth:
-  enabled: true          # 铸造总开关
-  cookieTtlSeconds: 0    # 0 = 跟随 session.ttlSeconds（默认 7 天）
-```
-
-> Cookie 有效窗口不能超过 `client-connection` 的 `cookieMaxAgeDays`（默认 30 天），插件已自动
-> 收敛到该上限；若你调低了部署里的 `cookieMaxAgeDays`，请把 `cookieTtlSeconds` 一并调低。
-> `trustProxy: false` 且在 dsh 侧配置了 `--trusted-host <域名>` 的部署同样被覆盖：此时插件只铸造
-> 绑定原始公网 Host 的那枚 Cookie，围栏由 `trustedHosts` 放行。
-
-### 4. 存储（`lib/store.js`）
-
-`$DSH_HOME/auth/store.json`（0600，原子写入）：
-
-```jsonc
-{
-  "version": 1,
-  "secret": "<base64url 32B>",          // 会话/MFA 令牌签名密钥
-  "accounts": [{
-    "username": "admin",
-    "role": "admin",
-    "passwordHash": "scrypt$<salt>$<hash>",
-    "protected": true,                  // 首个账号：不可删/不可改角色
-    "totp": { "secret": "<base32>", "verified": true, "createdAt": 0 },  // 未启用则为空
-    "backupCodes": [{ "hash": "<sha256>", "usedAt": 0 }],                // 备用码仅存哈希
-    "createdAt": 0, "updatedAt": 0, "lastLoginAt": 0
-  }]
-}
-```
-
-迁移逻辑：老存储无 `protected` 字段时，按 `createdAt` 最早的账号自动标记为受保护并落盘。
-
-### 5. TOTP（`lib/totp.js`，零依赖）
-
-- base32 编解码（RFC 4648）、`otpauth://` URI 构造；
-- TOTP = HMAC-SHA1(secret, 8 字节大端计数器) 动态截断取 6 位，30 秒周期；验证支持 ±window
-  步长；已用 RFC 6238 SHA-1 附录测试向量（T=0..5）验证；
-- 备用码：10 个 8 位无歧义字符码，仅存 SHA-256 哈希，每个可用一次。
-
-### 6. 登录页（`lib/login-page.js`）
-
-由被包装的 fallback 在未认证时直接内联输出，**零外部资源**。阶段机：
-`password → (code | offer) → setup`：
-
-- 密码步骤 → 有 MFA 则进入动态码步骤（含"有效剩余 N 秒"倒计时、6 位自动提交）；
-- 无 MFA 则展示"绑定双重验证"引导（可跳过）；
-- 绑定步骤展示二维码（`/auth/mfa/setup` 返回的 SVG data URL）+ 密钥 + otpauth + 备用码 +
-  验证输入，验证成功跳转 `next`；
-- 表单 `novalidate` + JS 手动校验（避免隐藏必填控件阻塞提交）。
-
-### 7. 浏览器半区（`lib/client.js`）
-
-手写 `window.__ModuleLoader__.load({id, factory})` 格式（与官方包一致，无需打包），通过
-`require("react")` / `react-dom/client` 挂载：
-
-- **重登浮层**：`/auth/me` 轮询（15s + focus），未认证且启用认证时全屏覆盖登录（支持 MFA 第二步）；
-- **设置 → 登录与账号**（`settings.section` slot，带用户图标，用 CSS 隐藏 shell 默认齿轮）：
-  状态、MFA 自服务、账号卡片列表（重置密码/禁用 MFA/删除）、退出登录；
-- 所有数据走 `fetch("/auth/*")`（同源 Cookie），不依赖 settings 域（第三方程无法注册）。
-
-### 8. 目录选择器替换（`cordis.patch.yml`）
-
-补丁行**不能改名**（`name mismatch` 会被跳过），因此用"禁用 + 插入"：
-
-```yaml
-- id: directory-picker        # 禁用 auto 选择器（loopback 下会解析成 native、在宿主弹窗）
-  disabled: true
-- insert:
-    - id: directory-picker-browse      # browse 宿主后端（host.listDirectory / createDirectory）
-      name: '@deepseek-ai/dsh-host-directory-picker-browse'
-      config: { maxEntries: 1000 }
-    - id: directory-picker-browse-ui   # 浏览器端目录对话框
-      name: '@deepseek-ai/dsh-client-ui-directory-picker-browse'
-```
-
-### 9. 安全模型（威胁分析）
-
-| 攻击面 | 防护 |
-|---|---|
-| 未认证访问 `/api` / 静态页 / WebSocket | 门禁 403 / 登录页 / 握手拒绝 |
-| 密码爆破 | scrypt + 限速（IP+用户名） |
-| 会话伪造/篡改 | HMAC 签名 + 过期 + 常量时间比较 + 账号存在性校验 |
-| 会话重放（MFA 第二步） | 一次性 nonce + 5 分钟 TTL |
-| 远程抢先注册管理员 | bootstrap 仅 loopback |
-| 误删唯一管理员 | 受保护账号 + 最后管理员保护 |
-| 跨站请求（CSRF） | HttpOnly + SameSite=lax；跨站请求带不上 Cookie，门禁即 403 |
-| DNS rebinding | 认证层已接管围栏语义；未认证请求不会到达围栏 |
-
----
-
-## 五、远程部署
-
-`dsh web` 仍拒绝 `--host 0.0.0.0`，请用反向代理暴露（TLS 终结 + WebSocket 转发）：
+`dsh web` 只监听本机，请用反向代理暴露（需转发 WebSocket）：
 
 ```nginx
 server {
@@ -485,40 +69,69 @@ server {
   location / {
     proxy_pass http://127.0.0.1:3080;
     proxy_http_version 1.1;
-    proxy_set_header Upgrade $http_upgrade;      # WebSocket（events.mux/host）
+    proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";
-    proxy_set_header Host $host;                 # 保留外部 Host
+    proxy_set_header Host $host;
     proxy_set_header Origin $http_origin;
   }
 }
 ```
 
-同样适用于 `ssh -R` 隧道、Tailscale、Frp 等。HTTPS 部署时把 `session.secure` 设为 `true`。
+`ssh -R` 隧道、Tailscale、Frp 等同样适用。HTTPS 部署请在配置中把 `session.secure` 设为
+`true`。
 
-## 六、多账号体系（设计思考）
+## 配置
 
-- **已实现**：多账号 + 角色（admin/user/guest）、集中管理、MFA、审计字段（创建/更新/最近登录）；
-- **做不了**：每用户独立工作区/会话（多租户数据隔离）——DSH 核心是单租户（`$DSH_HOME` 进程级
-  共享），事件流、搜索、任务等全局泄漏无法在插件层隔离；
-- **推荐**：每人一个 profile 实例（`dsh --profile alice --port 3081`）天然隔离数据；共享实例
-  协作则用角色体系。
+编辑 `~/.dsh/profiles/web/cordis.patch.yml` 中 `remote` 行的 config。常用项：
 
-## 七、端点一览
+```yaml
+- id: remote
+  config:
+    enabled: true          # false = 关闭门禁（被锁在门外时的逃生通道）
+    session:
+      secure: false        # HTTPS 部署改为 true
+    adminOnly: true        # false = 启用多角色（admin/user/guest）与账号管理
+    bootstrap:             # 可选：预置首个管理员（仅账号库为空时生效）
+      username: admin
+      password: '换成一个强密码'
+```
 
-| 方法 | 路径 | 说明 |
-|---|---|---|
-| POST | `/auth/login` | 登录；有 MFA 时返回 `{mfaRequired, mfaToken}`（不签 Cookie） |
-| POST | `/auth/mfa/login` | 第二步：`{mfaToken, code}`（动态码或备用码） |
-| POST | `/auth/logout` | 清除 Cookie |
-| GET | `/auth/me` | `{authEnabled, bootstrap, authenticated, username, role, mfa, adminOnly}` |
-| POST | `/auth/bootstrap` | 首个管理员引导（仅 loopback、仅空存储） |
-| POST | `/auth/mfa/setup` | 生成密钥 + otpauth + 二维码 + 备用码（pending 状态） |
-| POST | `/auth/mfa/verify` | 用动态码确认 pending 设置 |
-| POST | `/auth/mfa/disable` | 关闭本账号 MFA（需密码 + 有效动态码/备用码） |
-| POST | `/auth/accounts` | 管理员：`{action: list\|upsert\|remove\|disable-mfa, ...}` |
+默认值即开箱可用；完整配置项（会话、MFA、限速、gzip、文件面板等）见
+[docs/REFERENCE.md](docs/REFERENCE.md#13-完整配置参考cordispatchyml)。
 
-## 八、限制与逃生通道
+### 无浏览器服务器（headless）
 
-- Web 表面禁用 HMR，改配置后**必须重启 `dsh web`**；
-- 逃生：`enabled: false` 重启即恢复；或删除 `$DSH_HOME/auth/store.json` 重新引导；
-- 恢复原生目录选择器：见"代码层面实现"第 8 节的补丁片段（反转 disabled）。
+在 `cordis.patch.yml` 中加 `bootstrap` 配置节（见上），重启即预置首个管理员，等价于本机
+引导。首次登录后建议移除明文密码并绑定 MFA。
+
+## 常见问题
+
+| 现象 | 处理 |
+|---|---|
+| 安装后没有登录页 | 重启 `dsh web`；确认 bundles 列表里有 `@xgone/dsh-remote` |
+| 创建管理员时报 403 | 首个管理员仅限本机创建：在本机浏览器操作，或 `ssh -L` 后访问 `127.0.0.1`；无本地浏览器用 `bootstrap` 配置 |
+| 被锁在门外 | `cordis.patch.yml` 设 `enabled: false` 重启；或删除 `$DSH_HOME/auth/store.json` 重新引导 |
+| 忘记 MFA / 丢手机 | 管理员登录后：设置 → 登录与账号 → 该账号 → 禁用 MFA |
+| 文件面板提示 `outside-roots` | 设置 → 登录与账号 → 允许的目录，添加该目录（即时生效，无需重启） |
+| 升级 dsh 后登录成功但 `/api` 全部 401 | 升级本插件（≥ 0.3.1）并**重新登录一次**，见 [CHANGELOG](CHANGELOG.md) |
+| 升级 dsh 后远程设置页异常 / 反复弹窗 | 先升级本插件——新版 DSH 的远程兼容修复随版本内置，见 [CHANGELOG](CHANGELOG.md) |
+
+## 文档
+
+- **更新记录**：[CHANGELOG.md](CHANGELOG.md) —— 每个版本的变更与「升级 dsh 后」兼容修复；
+- **技术细节**：[docs/REFERENCE.md](docs/REFERENCE.md) —— 架构、实现机制、完整配置与端点
+  参考（供 AI agent 与贡献者查阅）。
+
+## 卸载
+
+```sh
+dsh plugin --profile web remove @xgone/dsh-remote
+```
+
+重启 `dsh web` 后门禁消失；账号数据保留在 `$DSH_HOME/auth/store.json`（彻底清除可手动删除）。
+
+## 已知限制
+
+- 改配置后必须重启 `dsh web`（Web 表面禁用 HMR）；
+- 多账号共享同一份工作区与会话数据——DSH 核心是单租户，插件层无法隔离；需要隔离请每人一个
+  profile 实例（`dsh --profile alice --port 3081`）。

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -1,0 +1,291 @@
+# dsh-remote 技术参考（AI agent / 贡献者向）
+
+> 本文件面向 AI agent 与贡献者，收录完整实现细节、内部机制与完整配置 / 端点参考。
+> 普通用户请看 [README](../README.md)；版本历史见 [CHANGELOG](../CHANGELOG.md)。
+> 内容与 `lib/` 源码同步维护，改动实现时请同步更新本文件。
+
+## 1. 项目定位与宿主约束
+
+- dsh-remote 是 `dsh web` 之前的**认证层**：全量门禁（HTTP + WebSocket）+ 账号 / 会话 / MFA，
+  并打通外网部署（反向代理后远程浏览器可用全部功能，宿主机不弹原生窗口）。
+- DSH 宿主的关键事实（决定了许多设计）：
+  - `webServer` 路由模型是「精确表 → 前缀表 → fallback」，**没有中间件钩子**；
+  - 内置浏览器信任围栏（`dsh-client-connection`）把 `host.pickDirectory`、`settings.*`、
+    `credentials.*` 等特权方法硬编码钉死在 loopback（官方注明「直到真正的认证层出现」）；
+  - 对远程（非 loopback）浏览器，整个设置面被切成 memory 模式（见 §15）；
+  - Web 表面**禁用 HMR**，bundle 补丁不能热重载，改动后必须重启 `dsh web`；
+  - DSH 核心是单租户（`$DSH_HOME` 进程级共享），插件层无法做多租户数据隔离（见 §16）。
+- 插件形态：**Cordis 双半区包 + bundle 补丁**。安装后 `dsh plugin` 自动把包追加进 profile 的
+  `dsh.profile.bundles`（因为 package.json 声明 `dsh.bundle.patch`），随下次 composition 生效。
+
+## 2. 仓库结构
+
+```
+dsh-remote/
+├── cordis.patch.yml   # bundle 补丁：插入 remote 行；禁用原生目录选择器并替换为 browse 后端
+├── lib/
+│   ├── index.js       # 宿主半区：门禁、会话、限速、角色、trustProxy、/auth/* 路由、gzip、文件服务
+│   ├── store.js       # 账号存储（scrypt 哈希、受保护标记、TOTP 状态、备用码哈希）
+│   ├── totp.js        # RFC 6238 TOTP / base32 / otpauth URI / 备用码（零依赖）
+│   ├── login-page.js  # 自包含登录页（密码 → 动态码 → 绑定引导，含二维码），zh/en
+│   ├── files-store.js # 允许目录的持久化（dsh-remote-files.json，0600 原子写入）
+│   └── client.js      # 浏览器半区：重登浮层、设置页「登录与账号」、远程文件侧栏、语言持久化
+├── test/              # node --test：gzip / remote-file / role-gate / files-store / browser-auth
+└── package.json       # dsh.bundle.patch + dsh.client 声明 + ./client 导出
+```
+
+- 宿主半区以 `inject: ["webServer"]` 激活；浏览器半区由客户端模块系统扫描进
+  `window.__DSH_BOOT__`，挂到 `settings.section` slot 与覆盖层。
+- 浏览器半区**零打包**：手写 `window.__ModuleLoader__.load({id, factory})` 格式（与官方包一致），
+  经 `require("react")` / `react-dom/client` 挂载。
+
+## 3. 门禁（lib/index.js）
+
+通过「包装路由注册方法 + 就地包装已注册表项」实现全量门禁：
+
+- 包装 `register` / `registerUpgrade` / `registerFallback` 三个方法，并对
+  `webServer.exact / prefixes / upgrades` 与 `fallback` 中**已注册**的每一项逐个包装：
+  `Symbol` 标记防止重复包装；`WeakMap` 记录原始处理器，卸载时还原。
+- 包装后的 HTTP 处理器流程：
+  `/auth/*` 放行 → 无有效会话时页面请求返回登录页、其余 403 → 通过后**先归一化
+  Host/Origin 再交给下层**（trustProxy，见 §5）→ 浏览器认证 Cookie 自愈补发（见 §6）。
+- WebSocket 升级握手：无 Cookie 直接销毁 socket。
+- 角色门禁（`enforceRoles` 开启且会话非 admin 时）：读取 RPC 信封（上限 16 MiB），按
+  `method` 查拒绝表，命中返回 403；放行时用可重放请求体（`Readable` + `Proxy`）交给下层；
+  admin 会话零开销。
+- **角色门禁只作用于 `type: "client-request"` 封包**：`/api/respond` 等应答封包没有 `method`
+  字段，不能按方法判定。被拒的 client-request 返回符合 RPC 契约的 `server-response` 错误封包
+  （回显 rpcId），浏览器按业务错误处理而不是传输故障（v0.2.7 修复）。
+- 方法名归一化：dsh alpha 用 `namespace/method`（斜杠），rc 用点号；服务端先把斜杠归一化为
+  点号再匹配拒绝表，两代 dsh 限制一致。
+
+## 4. 会话与口令
+
+- **会话 Cookie**：`v1.<base64url payload>.<HMAC-SHA256 sig>`，payload `{sub, role, iat, exp}`；
+  验证时重算签名并常量时间比较，且账号必须仍存在（删除即失效）。
+- **MFA 挑战令牌**：`mfa.<payload>.<sig>`，5 分钟有效、一次性（nonce 消费集合防重放）。
+- **口令**：scrypt（`node:crypto`，`N=16384,r=8,p=1`），异步验证 + 常量时间比较，绝不落盘明文。
+- **限速**：内存表按「IP + username」计数（默认 15 分钟窗口 5 次）；密码步骤与 MFA 步骤用
+  不同键（MFA 失败计数不会被成功密码步骤清掉）。
+- **首个账号**：`protected: true`，不可删除、不可改角色，仅可重置密码；bootstrap 仅限
+  loopback 提交，防止远程抢先注册。
+
+## 5. trustProxy 与 DSH 信任围栏
+
+DSH 围栏校验：`Host`（loopback 或 `trustedHosts`）、`Origin` 与 Host 一致、`sec-fetch-site`
+非 cross-site，且特权方法硬编码 loopback。插件在**认证通过后**把请求的 `Host`/`Origin`
+归一化为 `127.0.0.1:<端口>`（保留原 scheme）再交给下层——围栏判定为 loopback，特权方法对
+外部浏览器放行。未认证请求仍被门禁 403，围栏的 DNS-rebinding 语义在 Cookie 之后不再需要。
+默认 `trustProxy: true`；`false` 时可用 dsh 原生 `--trusted-host <域名>` 放行围栏
+（此时 browserAuth 只铸造绑定原始公网 Host 的 Cookie，见 §6）。
+
+## 6. dsh ≥ 0.1.2-alpha 适配：dsh-auth-* Cookie 铸造（issue #10）
+
+- 背景：alpha 起 `client-connection` 在围栏之外还要求一个**绑定请求 Host** 的持久化签名
+  Cookie（`dsh-auth-<sha256(Host)>`，HMAC-SHA256，密钥在 `$DSH_HOME/.credentials.yaml` 的
+  `client-connection/browser-session` 记录），`/api`、流式 WebSocket（`/api/remote.mux`）与
+  index.html 都校验。它只能由 dsh 自己的 `?token=<启动令牌>` 流程铸造，远程浏览器两者皆不可得，
+  登录后所有 `/api` 401。
+- 插件适配（默认开启，`browserAuth.enabled`）：
+  - **登录 / MFA / 引导成功时**读取 client-connection 的持久化签名密钥，用核心同款算法铸造
+    两枚 Cookie：绑定**归一化 loopback authority**（供 `/api` 与 WebSocket）+ 绑定**原始公网
+    Host**（供 index.html / 静态回退）；
+  - **自愈补发**：每个经过门禁的请求校验 Cookie 是否在位且有效（含核心自铸的），缺失或失效时
+    在当前响应上补发——旧会话、被清理过 Cookie 的会话下一次请求自动修复；
+  - **旧版兼容**：读不到凭证记录（或运行时无 `credentials` 服务）时自动关闭，行为与 0.3.0 一致。
+- 约束：Cookie 有效窗口不超过 `client-connection` 的 `cookieMaxAgeDays`（默认 30 天），
+  插件自动收敛到该上限；部署调低 `cookieMaxAgeDays` 时需同步调低 `browserAuth.cookieTtlSeconds`。
+- **浏览器半区 RPC 形状自适应**：alpha 端点改名 `namespace/method` 且信封收窄为单一 `args`
+  字段（`settings.describe` → `settings/describe`）。客户端先试新形状、404 回落旧点号形状并按
+  页面缓存——同一份 bundle 同时服务 rc 与 alpha。
+
+## 7. 存储格式
+
+### `$DSH_HOME/auth/store.json`（0600，原子写入）
+
+```jsonc
+{
+  "version": 1,
+  "secret": "<base64url 32B>",          // 会话/MFA 令牌签名密钥（空配置时自动生成并持久化）
+  "accounts": [{
+    "username": "admin",
+    "role": "admin",
+    "passwordHash": "scrypt$<salt>$<hash>",
+    "protected": true,                  // 首个账号：不可删/不可改角色
+    "totp": { "secret": "<base32>", "verified": true, "createdAt": 0 },  // 未启用则为空
+    "backupCodes": [{ "hash": "<sha256>", "usedAt": 0 }],                // 备用码仅存哈希
+    "createdAt": 0, "updatedAt": 0, "lastLoginAt": 0
+  }]
+}
+```
+
+迁移：老存储无 `protected` 字段时，按 `createdAt` 最早的账号自动标记为受保护并落盘。
+删除该文件 = 清空账号回到引导模式（逃生通道）。
+
+### `$DSH_HOME/dsh-remote-files.json`（0600，原子写入）
+
+设置页管理的「允许的目录」列表（见 §13 `files` 节）。配置文件提供的根目录（DSH 主目录 +
+dsh 进程工作目录、旧配置 `files.roots`）只读并列展示，不受设置页管理。
+
+## 8. TOTP（lib/totp.js，零依赖）
+
+- base32 编解码（RFC 4648）、`otpauth://` URI 构造；
+- TOTP = HMAC-SHA1(secret, 8 字节大端计数器) 动态截断取 6 位，30 秒周期；验证支持 ±window
+  步长（默认 ±1）；已用 RFC 6238 SHA-1 附录测试向量（T=0..5）验证；
+- 备用码：10 个 8 位无歧义字符码，仅存 SHA-256 哈希，每个可用一次。
+
+## 9. 登录页（lib/login-page.js）
+
+由被包装的 fallback 在未认证时直接内联输出，**零外部资源**。阶段机：
+`password → (code | offer) → setup`：
+
+- 密码步骤 → 有 MFA 进入动态码步骤（「有效剩余 N 秒」倒计时、6 位自动提交；备用码含字母，
+  仍手动确认）；无 MFA 展示「绑定双重验证」引导（可跳过）；
+- 绑定步骤：二维码（`/auth/mfa/setup` 返回 SVG data URL）+ 手动密钥 + otpauth + 备用码 +
+  验证输入，成功跳转 `next`；
+- 表单 `novalidate` + JS 手动校验（避免隐藏必填控件阻塞提交）；
+- 服务端渲染时语言取 `$DSH_HOME/settings.yaml` 的 `locale.preference`，未设置回落浏览器
+  `Accept-Language`。
+
+## 10. 浏览器半区（lib/client.js）
+
+- **重登浮层**：`/auth/me` 轮询（15s + focus），未认证且启用认证时全屏覆盖登录（支持 MFA
+  第二步）。
+- **设置 → 登录与账号**（`settings.section` slot，用户图标；CSS 隐藏 shell 默认齿轮）：
+  状态、MFA 自服务（开启/关闭）、账号卡片列表（重置密码 / 禁用 MFA / 删除）、允许的目录管理、
+  退出登录。所有数据走 `fetch("/auth/*")`（同源 Cookie），不依赖 settings 域（第三方代码无法
+  在该域注册）。
+- **远程文件侧栏**：拦截远程（非 loopback，按 `location.hostname` 判定）浏览器的
+  `host.openPath` RPC（含 `type: "server-response"` 的合规假响应），改为流式加载
+  `/auth/file` 面板：Markdown 用界面同款渲染器、图片 / PDF / 视频内联、文本等宽、目录逐级浏览；
+  多面板上下等分、面板最大化 / 关闭、侧栏左缘拖拽调宽、Esc 关闭最上 / 放大面板；不可预览的
+  二进制提供下载兜底。文件读取做 realpath 校验，符号链接逃逸与 `..` 穿越一律拒绝；
+  范围外路径报 `outside-roots`（提示含 `allowedRoots`，指向设置页）。loopback 访问不拦截，
+  保持 DSH 原生行为。
+- **主题**：全部界面用官方设计令牌 `--dsw-alias-*` 取色，自动跟随 DSH 浅色 / 深色 / 跟随系统。
+- **语言**：接入官方 `@deepseek-ai/dsh-client-locale`（`ctx.locale`），注册 zh/en 字典实时切换。
+
+## 11. 目录选择器替换（cordis.patch.yml）
+
+补丁行不能改名（`name mismatch` 会被跳过），因此用「禁用 + 插入」：
+
+```yaml
+- id: directory-picker        # 禁用 auto 选择器（loopback 下解析成 native、在宿主弹窗）
+  disabled: true
+- insert:
+    - id: directory-picker-browse      # browse 宿主后端（host.listDirectory / createDirectory）
+      name: '@deepseek-ai/dsh-host-directory-picker-browse'
+      config: { maxEntries: 1000 }
+    - id: directory-picker-browse-ui   # 浏览器端目录对话框（双栏 + 面包屑 + 新建文件夹）
+      name: '@deepseek-ai/dsh-client-ui-directory-picker-browse'
+```
+
+恢复原生选择器：反转 `disabled` 标记并删除 `insert` 块。
+
+## 12. 安全模型（威胁分析）
+
+| 攻击面 | 防护 |
+|---|---|
+| 未认证访问 `/api` / 静态页 / WebSocket | 门禁 403 / 登录页 / 握手拒绝 |
+| 密码爆破 | scrypt + 限速（IP+用户名） |
+| 会话伪造 / 篡改 | HMAC 签名 + 过期 + 常量时间比较 + 账号存在性校验 |
+| 会话重放（MFA 第二步） | 一次性 nonce + 5 分钟 TTL |
+| 远程抢先注册管理员 | bootstrap 仅 loopback |
+| 误删唯一管理员 | 受保护账号 + 最后管理员保护 |
+| 跨站请求（CSRF） | HttpOnly + SameSite=lax；跨站请求带不上 Cookie，门禁即 403 |
+| DNS rebinding | 认证层已接管围栏语义；未认证请求不会到达围栏 |
+| 任意文件读取 | realpath 校验 + 允许目录白名单 + 符号链接 / `..` 拒绝 |
+
+## 13. 完整配置参考（cordis.patch.yml）
+
+`~/.dsh/profiles/web/cordis.patch.yml`（覆盖 remote 行的整份 config，缺省键回落默认值）：
+
+```yaml
+- id: remote
+  config:
+    enabled: true            # false = 完全关闭门禁（逃生通道）
+    accounts: []             # 种子账号（明文密码启动时转 scrypt；或直接给 scrypt$<salt>$<hash>）
+    secret: ''               # 空 = 自动生成并持久化到 store.json
+    session:
+      cookieName: dsh_session
+      ttlSeconds: 604800     # 7 天
+      secure: false          # HTTPS 部署建议 true
+      sameSite: lax
+    enforceRoles: true       # admin/user/guest 方法级权限
+    adminOnly: true          # 仅管理员账号（默认）；false 启用多角色与账号管理
+    trustProxy: true         # 认证后归一化 Host/Origin（见 §5）
+    bootstrap:               # 无浏览器服务器预置首个管理员（账号库为空时生效，幂等）
+      username: admin
+      password: '...'        # 至少 6 位，违规启动报错
+    mfa:
+      enabled: true
+      issuer: DeepSeek Harness
+      window: 1              # ±1 个 30 秒步长
+      backupCodes: 10
+    rateLimit:
+      maxAttempts: 5
+      windowMs: 900000       # 15 分钟
+    gzip:
+      enabled: true          # 响应 gzip 总开关
+      remoteOnly: true       # 仅对远程（非 loopback Host）压缩
+      minBytes: 1024         # 已知 Content-Length 小于此值不压缩
+    files:
+      enabled: true          # 远程文件面板（/auth/file）总开关
+      maxListing: 500        # 目录索引每页最多条目
+      # files.roots: []      # 旧配置：兼容生效但只读展示，新增目录请用设置页（§10）
+    browserAuth:
+      enabled: true          # dsh-auth-* Cookie 铸造总开关（见 §6）
+      cookieTtlSeconds: 0    # 0 = 跟随 session.ttlSeconds；上限 client-connection.cookieMaxAgeDays
+```
+
+## 14. HTTP 端点一览
+
+| 方法 | 路径 | 说明 |
+|---|---|---|
+| POST | `/auth/login` | 登录；有 MFA 时返回 `{mfaRequired, mfaToken}`（不签 Cookie） |
+| POST | `/auth/mfa/login` | 第二步：`{mfaToken, code}`（动态码或备用码） |
+| POST | `/auth/logout` | 清除 Cookie |
+| GET | `/auth/me` | `{authEnabled, bootstrap, authenticated, username, role, mfa, adminOnly}` |
+| POST | `/auth/bootstrap` | 首个管理员引导（仅 loopback、仅空存储） |
+| POST | `/auth/mfa/setup` | 生成密钥 + otpauth + 二维码 + 备用码（pending 状态） |
+| POST | `/auth/mfa/verify` | 用动态码确认 pending 设置 |
+| POST | `/auth/mfa/disable` | 关闭本账号 MFA（需密码 + 有效动态码/备用码） |
+| POST | `/auth/accounts` | 管理员：`{action: list\|upsert\|remove\|disable-mfa, ...}` |
+| GET | `/auth/file` | 远程文件面板的流式文件读取（受允许目录白名单约束） |
+
+## 15. 已处理的 DSH 远程浏览器怪癖（settings memory 模式系列）
+
+DSH 对远程（非 loopback）浏览器把设置相关状态切成 memory 模式（读写在客户端被丢弃），
+引发一系列问题，插件全部**只用官方 slots/store/RPC** 修复，不重写 DSH 内部方法、不改
+persistence：
+
+| 版本 | 怪癖 | 修复机制 |
+|---|---|---|
+| v0.1.5 | 所有 settings scope memory 模式 → 远程「设置 → 插件」配置卡片空白 | 启动时解除 scope 限制并触发全量刷新（settings.yaml 文档编辑器保持仅限本机，设计如此） |
+| v0.1.6 | `WelcomeNoticeStore` memory 模式不读持久化确认 → 反复弹「内测声明」 | 经 `settings.describe` 读 `ui-onboarding.welcomeNoticeVersion`，有值时经 `store.update` 置 `acknowledged=true`；纯远程首次用户维持原行为 |
+| v0.2.6 | 共享 `SettingsDescribeMirror` 远程为 memory（`view` 恒 undefined）→ Models 页报 "settings are unavailable" | `settings.describe` 读设置文档 → `ctx.settingsScope.describe()` 拿 mirror → `store.set` 注入 view |
+| v0.1.2 | 语言偏好远程刷新即丢 | 读：启动经 `settings.describe` 取回并应用；写：切换经 `settings.mutate` 落盘 `settings.yaml`。loopback 访问不介入 |
+
+## 16. 多账号边界（租户隔离做不到的事）
+
+- **已实现**：多账号 + 角色（admin/user/guest）、集中管理、MFA、审计字段（创建/更新/最近登录）。
+- **插件层做不到**：每用户独立工作区/会话（多租户数据隔离）——DSH 核心单租户（`$DSH_HOME`
+  进程级共享），事件流、搜索、任务等全局泄漏无法在插件层隔离。
+- **推荐**：每人一个 profile 实例（`dsh --profile alice --port 3081`）天然隔离；共享实例协作
+  用角色体系。
+
+## 17. 限制与逃生通道
+
+- Web 表面禁用 HMR：改配置后**必须重启 `dsh web`**；
+- 逃生：`cordis.patch.yml` 设 `enabled: false` 重启即恢复原生；删除
+  `$DSH_HOME/auth/store.json` 重新引导；
+- 恢复原生目录选择器：见 §11（反转 `disabled`）；
+- 被锁在门外：见上两条；忘记 MFA：管理员可在设置页为任意账号禁用 MFA（需管理员密码）。
+
+## 18. 开发与测试
+
+- 语法检查：`npm run check`（`node --check lib/index.js`）；
+- 测试：`npm test`（node:test：gzip / remote-file / role-gate / files-store / browser-auth）；
+  `prepublishOnly` 同样执行，发版走 tag 触发的 CI；
+- 浏览器半区无构建步骤（手写 ModuleLoader 模块），改动 `lib/client.js` 后需重启 `dsh web`
+  并强刷浏览器验证。


### PR DESCRIPTION
## Summary
- Slim **README.md / README.en.md** (524→137 / 603→151 lines): rewritten from the user's perspective — intro, screenshots, feature highlights, quick start, essential config, short FAQ, uninstall & known limitations.
- Add **CHANGELOG.md**: per-version history (v0.1.1 → 0.3.1, verified per tag), absorbing the four "after a dsh upgrade" compatibility narratives previously buried in the FAQ.
- Add **docs/REFERENCE.md** (291 lines): distilled technical details for AI agents & contributors — host constraints, gate/session/trustProxy/browserAuth internals, storage schema, threat model, full config reference, endpoint list, DSH remote-quirk fix table, dev & test.

Cross-links and anchors verified; screenshots untouched.