### PR TITLE
fix(client): restore the remote file panel on dsh >= 0.1.2-alpha (issue #11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 用户指南见 [README](README.md)；实现细节见 [docs/REFERENCE.md](docs/REFERENCE.md)。
 
+## 0.3.2 (2026-09-02)
+
+- **适配 dsh ≥ 0.1.2-alpha（issue #11）：远程文件侧栏在新版 dsh 上完全失效**。两层原因，均已修复：
+  1. 新版把原生打开 RPC 从 `host.openPath`（点号端点，`payload.path`）整个换成了
+     `session.openWorkspacePath`（斜杠端点 `/api/session/openWorkspacePath`，参数包在
+     `payload.args.request.path`），客户端 fetch 拦截只匹配旧形状，永远拦不到。拦截器现在
+     同时匹配两代端点形状（`args` 按方法参数名泛化查找 `path`），同一份 bundle 继续同时
+     服务 rc 与 alpha。
+  2. 新版 UI 新增客户端门闩：产物文件「打开」入口只在 `ctx.remote.$host.isLoopback` 为真时
+     渲染（`canOpenPath = isLoopback && hostCanOpenPath`），远程浏览器根本不渲染按钮，拦截
+     无从谈起。插件在远程页面把 connection 事实源翻转为可达（客户端半区的 `trustProxy`：
+     门禁层已放行认证请求，服务端角色门禁仍是执行点），入口恢复渲染、点击进侧栏。
+- 随附：设置平面在远程浏览器改走与 loopback 相同的 host 持久化路径（受服务端角色门禁约束，
+  非 admin 的 settings 写入依旧拒绝）；角色门禁拒绝表补齐 alpha 新名（`session.openWorkspacePath`、
+  `settings.openSettingsDocument`、`settings.openAgentPresetDirectory`），非 admin 依旧无法
+  触发宿主机桌面打开。
+- **升级插件并重启 `dsh web` 后，远程浏览器无需重新登录。**
+
 ## 0.3.1 (2026-09-02)
 
 - **适配 dsh ≥ 0.1.2-alpha（issue #10）**：新版 dsh 的 `client-connection` 额外要求绑定请求 Host 的 `dsh-auth-*` 持久化签名 Cookie，远程浏览器拿不到，导致登录成功后所有 `/api` 返回 401（index.html 也可能 401）。插件现在在登录 / MFA / 引导成功时用核心同款算法铸造并下发两枚 Cookie（分别绑定归一化 loopback 与原始公网 Host），并在门禁层自愈补发。**升级插件后重新登录一次即可**；升级前创建的旧会话在下一次请求时自动修复，无需重新登录。

--- a/README.en.md
+++ b/README.en.md
@@ -125,6 +125,7 @@ plaintext password and bind MFA.
 | Lost MFA / phone | As admin: Settings → Auth & Accounts → that account → Disable MFA |
 | File panel reports `outside-roots` | Settings → Auth & Accounts → Allowed directories: add the directory (applies immediately, no restart) |
 | After a dsh upgrade every `/api` call returns 401 despite a successful login | Upgrade this plugin (≥ 0.3.1) and **sign in once more** — see the [CHANGELOG](CHANGELOG.md) |
+| After a dsh upgrade clicking a file path does nothing / never opens the sidebar | Upgrade this plugin (≥ 0.3.2) and restart `dsh web` — see the [CHANGELOG](CHANGELOG.md) |
 | Settings pages misbehave / popups return after a dsh upgrade | Upgrade this plugin first — compatibility fixes for new DSH versions ship built-in, see the [CHANGELOG](CHANGELOG.md) |
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ server {
 | 忘记 MFA / 丢手机 | 管理员登录后：设置 → 登录与账号 → 该账号 → 禁用 MFA |
 | 文件面板提示 `outside-roots` | 设置 → 登录与账号 → 允许的目录，添加该目录（即时生效，无需重启） |
 | 升级 dsh 后登录成功但 `/api` 全部 401 | 升级本插件（≥ 0.3.1）并**重新登录一次**，见 [CHANGELOG](CHANGELOG.md) |
+| 升级 dsh 后点文件路径没反应 / 不再进侧边栏 | 升级本插件（≥ 0.3.2）并重启 `dsh web`，见 [CHANGELOG](CHANGELOG.md) |
 | 升级 dsh 后远程设置页异常 / 反复弹窗 | 先升级本插件——新版 DSH 的远程兼容修复随版本内置，见 [CHANGELOG](CHANGELOG.md) |
 
 ## 文档

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -155,13 +155,18 @@ dsh 进程工作目录、旧配置 `files.roots`）只读并列展示，不受�
   状态、MFA 自服务（开启/关闭）、账号卡片列表（重置密码 / 禁用 MFA / 删除）、允许的目录管理、
   退出登录。所有数据走 `fetch("/auth/*")`（同源 Cookie），不依赖 settings 域（第三方代码无法
   在该域注册）。
-- **远程文件侧栏**：拦截远程（非 loopback，按 `location.hostname` 判定）浏览器的
-  `host.openPath` RPC（含 `type: "server-response"` 的合规假响应），改为流式加载
-  `/auth/file` 面板：Markdown 用界面同款渲染器、图片 / PDF / 视频内联、文本等宽、目录逐级浏览；
-  多面板上下等分、面板最大化 / 关闭、侧栏左缘拖拽调宽、Esc 关闭最上 / 放大面板；不可预览的
-  二进制提供下载兜底。文件读取做 realpath 校验，符号链接逃逸与 `..` 穿越一律拒绝；
-  范围外路径报 `outside-roots`（提示含 `allowedRoots`，指向设置页）。loopback 访问不拦截，
-  保持 DSH 原生行为。
+- **远程文件侧栏**：拦截远程（非 loopback，按 `location.hostname` 判定）浏览器的原生打开
+  RPC（含 `type: "server-response"` 的合规假响应），改为流式加载 `/auth/file` 面板：Markdown
+  用界面同款渲染器、图片 / PDF / 视频内联、文本等宽、目录逐级浏览；多面板上下等分、面板最大化 /
+  关闭、侧栏左缘拖拽调宽、Esc 关闭最上 / 放大面板；不可预览的二进制提供下载兜底。文件读取做
+  realpath 校验，符号链接逃逸与 `..` 穿越一律拒绝；范围外路径报 `outside-roots`（提示含
+  `allowedRoots`，指向设置页）。loopback 访问不拦截，保持 DSH 原生行为。
+  两代 dsh 的端点形状不同，拦截器同时匹配：rc 为 `/api/host.openPath`（`payload.path`），
+  dsh ≥ 0.1.2-alpha 为 `/api/session/openWorkspacePath`（`payload.args.<参数名>.path`，
+  按参数名泛化查找）。alpha 还把打开入口的渲染钉在 `ctx.remote.$host.isLoopback` 上
+  （`canOpenPath = isLoopback && hostCanOpenPath`），插件因此在远程页面把 `ctx.connection`
+  的 `isLoopback` 事实翻转为真——客户端半区的 `trustProxy`：门禁层已放行认证请求，服务端
+  角色门禁仍是执行点（`session.openWorkspacePath` 等原生打开方法对非 admin 拒绝）。
 - **主题**：全部界面用官方设计令牌 `--dsw-alias-*` 取色，自动跟随 DSH 浅色 / 深色 / 跟随系统。
 - **语言**：接入官方 `@deepseek-ai/dsh-client-locale`（`ctx.locale`），注册 zh/en 字典实时切换。
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -30,7 +30,7 @@ window.__ModuleLoader__.load({
 
 		/** Client-bundle version marker — keep in sync with package.json on
 		 *  release; surfaced in the boot console line for remote debugging. */
-		const PLUGIN_VERSION = "0.3.0";
+		const PLUGIN_VERSION = "0.3.2";
 
 		/** User icon + markdown renderer from the shell's primitives set (cosmetic / preview; optional). */
 		let IconUserOutline16 = null;
@@ -363,19 +363,91 @@ window.__ModuleLoader__.load({
 			}
 		}
 
-		// ── remote file display: intercept host.openPath ─────────────────────────
-		// DSH's UI opens agent-produced files through the host.openPath RPC,
-		// which hands the path to the HOST desktop's default application — the
-		// remote user never sees it. For non-loopback browsers, intercept the
-		// /api fetch carrying that RPC and instead open the in-app file viewer
-		// (SidePanelHost below) backed by /auth/file on the host half: the
-		// file displays INSIDE this browser — markdown rendered, images / PDF /
-		// video inline, directories as a clickable listing. The RPC itself is
-		// answered locally with the same ok envelope the host would have
-		// returned, so callers' `.catch(() => {})` paths stay quiet. Loopback
-		// browsers keep DSH's native behavior. Patched at the fetch layer (not
-		// the runtime client) so every consumer (composer, artifacts, workspace
-		// tree) is covered without reaching into module internals.
+		// ── remote file display: intercept native-open RPCs ───────────────────────
+		// DSH's UI opens agent-produced files through a native-open RPC, which
+		// hands the path to the HOST desktop's default application — the
+		// remote user never sees it. The wire shape differs by generation:
+		//   rc    — POST /api/host.openPath,            payload { path }
+		//   alpha — POST /api/session/openWorkspacePath, payload { args: { request: { path } } }
+		// For non-loopback browsers, intercept the /api fetch carrying either
+		// and instead open the in-app file viewer (SidePanelHost below) backed
+		// by /auth/file on the host half: the file displays INSIDE this browser
+		// — markdown rendered, images / PDF / video inline, directories as a
+		// clickable listing. The RPC itself is answered locally with the same
+		// ok envelope the host would have returned, so callers' `.catch(() => {})`
+		// paths stay quiet. Loopback browsers keep DSH's native behavior.
+		// Patched at the fetch layer (not the runtime client) so every consumer
+		// (composer, artifacts, workspace tree) is covered without reaching
+		// into module internals.
+
+		/** Match one /api fetch against the native-open RPCs of both supported
+		 *  dsh wire generations. Returns `{ path, rpcId }` to display and echo,
+		 *  or null when this is not a native-open call (or the body is
+		 *  unreadable) and must pass through untouched. The alpha envelope
+		 *  names `args` entries after the authored method parameters, so the
+		 *  path is located generically instead of under a fixed key. Exported
+		 *  for unit tests. */
+		function extractNativeOpenPath(url, body) {
+			if (typeof url !== "string" || typeof body !== "string") return null;
+			if (url.indexOf("/api/host.openPath") === -1
+				&& url.indexOf("/api/session/openWorkspacePath") === -1) return null;
+			let envelope;
+			try {
+				envelope = JSON.parse(body);
+			} catch (error) {
+				return null;
+			}
+			const payload = envelope && typeof envelope === "object" ? envelope.payload : null;
+			if (payload === null || typeof payload !== "object") return null;
+			let path = null;
+			if (typeof payload.path === "string") path = payload.path;
+			else {
+				const args = payload.args;
+				if (args !== null && typeof args === "object") {
+					for (const key of Object.keys(args)) {
+						const value = args[key];
+						if (value !== null && typeof value === "object" && typeof value.path === "string") {
+							path = value.path;
+							break;
+						}
+					}
+				}
+			}
+			if (path === null) return null;
+			return { path, rpcId: typeof envelope.rpcId === "string" ? envelope.rpcId : null };
+		}
+
+		let remoteFileOpenInstalled = false;
+		function installRemoteFileOpen() {
+			if (remoteFileOpenInstalled) return;
+			remoteFileOpenInstalled = true;
+			const originalFetch = window.fetch;
+			if (typeof originalFetch !== "function") return;
+			window.fetch = function (input, init) {
+				try {
+					const url = typeof input === "string" ? input : String(input && input.url !== undefined ? input.url : input);
+					const body = init && init.body;
+					const matched = extractNativeOpenPath(url, typeof body === "string" ? body : null);
+					if (matched === null) return originalFetch.apply(this, arguments);
+					fileViewerStore.open(matched.path);
+					// The DSH client validates every /api body against
+					// serverResponseSchema, which DISCRIMINATES on
+					// type: "server-response". Omitting it made a correctly-opened
+					// file throw "Invalid input" (zod literal rejection on `type`)
+					// in remote browsers, so the pane opened but the UI still
+					// signalled "无法打开文件" (issue #9). Mirror the host's own
+					// envelope — the HTTP layer returns
+					// { rpcId, result: { ok: true, value } } tagged
+					// type: "server-response".
+					return Promise.resolve(new Response(
+						JSON.stringify({ type: "server-response", rpcId: matched.rpcId, result: { ok: true, value: { opened: true } } }),
+						{ status: 200, headers: { "Content-Type": "application/json" } }
+					));
+				} catch (error) {
+					return originalFetch.apply(this, arguments);
+				}
+			};
+		}
 
 		/** Same loopback classification DSH's connection plugin uses — computed
 		 *  from THIS page's location so the decision never depends on the
@@ -436,41 +508,6 @@ window.__ModuleLoader__.load({
 				return fileViewerStore.state;
 			}
 		};
-
-		let remoteFileOpenInstalled = false;
-		function installRemoteFileOpen() {
-			if (remoteFileOpenInstalled) return;
-			remoteFileOpenInstalled = true;
-			const originalFetch = window.fetch;
-			if (typeof originalFetch !== "function") return;
-			window.fetch = function (input, init) {
-				try {
-					const url = typeof input === "string" ? input : String(input && input.url !== undefined ? input.url : input);
-					if (url.indexOf("/api/host.openPath") === -1) return originalFetch.apply(this, arguments);
-					const body = init && init.body;
-					if (typeof body !== "string") return originalFetch.apply(this, arguments);
-					const envelope = JSON.parse(body);
-					const path = envelope && typeof envelope.payload?.path === "string" ? envelope.payload.path : null;
-					if (!path) return originalFetch.apply(this, arguments);
-					fileViewerStore.open(path);
-					// The DSH client validates every /api body with
-					// serverResponseSchema.parse(await response.json()), which
-					// DISCRIMINATES on type: "server-response". Omitting it made a
-					// correctly-opened file throw "Invalid input" (zod literal
-					// rejection on `type`) in remote browsers, so the pane opened
-					// but the UI still signalled "无法打开文件" (issue #9). Mirror
-					// the host's own envelope — ok() returns
-					// { rpcId, result: { ok: true, value } } and the HTTP layer
-					// tags it type: "server-response".
-					return Promise.resolve(new Response(
-						JSON.stringify({ type: "server-response", rpcId: envelope.rpcId, result: { ok: true, value: { opened: true } } }),
-						{ status: 200, headers: { "Content-Type": "application/json" } }
-					));
-				} catch (error) {
-					return originalFetch.apply(this, arguments);
-				}
-			};
-		}
 
 		// ── right side panel host (Claude Desktop style) ─────────────────────────
 		// DSH's native layout has a "details" right column, but it is a single
@@ -1496,6 +1533,29 @@ window.__ModuleLoader__.load({
 			// panel regardless of plugin load order. The boot log makes the
 			// loaded plugin version verifiable from the DevTools console.
 			if (!isLoopbackPage()) {
+				// dsh ≥ 0.1.2-alpha additionally gates its native-open affordances
+				// on the CLIENT-side loopback fact: the produced-files chips only
+				// render when `ctx.remote.$host.isLoopback` is true
+				// (ui-deliverables ProducedFiles: canOpenPath = isLoopback &&
+				// hostCanOpenPath), and ui-settings derives its persistence mode
+				// and document surfaces from the same fact. On rc generations the
+				// buttons always rendered and this plugin intercepted the click;
+				// on alpha they never render, so the panel could never open.
+				// This plugin IS the authentication layer for this page — its
+				// gate already passes authenticated requests through the loopback
+				// fence — so report the privileged surface as reachable, the
+				// client-side mirror of `trustProxy` on the host half. The
+				// server-side role gate remains the enforcement point. Applied
+				// during bundle load (the connection loop starts only after
+				// `loader.await()`), so `$host` re-mints its cached facts with
+				// the flipped value at the first ready frame.
+				try {
+					const connectionFacts = ctx.get("connection");
+					if (connectionFacts !== void 0 && connectionFacts.isLoopback === false) connectionFacts.isLoopback = true;
+				} catch (error) {
+					// connection service unavailable — page stays on DSH's native
+					// remote behavior (hidden open affordances)
+				}
 				installRemoteFileOpen();
 				console.info("[dsh-remote] " + PLUGIN_VERSION + ": remote browser detected — file panel active");
 			}
@@ -1649,6 +1709,9 @@ window.__ModuleLoader__.load({
 		exports.apply = apply;
 		exports.inject = inject;
 		exports.name = name;
+		/** Test-only surfaces: the wire-shape matcher and the fetch patch. */
+		exports.extractNativeOpenPath = extractNativeOpenPath;
+		exports.installRemoteFileOpen = installRemoteFileOpen;
 		return module.exports;
 	}
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -81,10 +81,17 @@ function isPublicPath(pathname) {
 	return pathname === "/auth" || pathname.startsWith("/auth/");
 }
 
-/** Wire methods any non-admin session may not call. */
+/** Wire methods any non-admin session may not call. Names exist per dsh
+ *  generation: the rc-era dotted entries and their dsh ≥ 0.1.2-alpha
+ *  renames (evaluateRoleGate normalizes `namespace/method` → dotted before
+ *  matching, so one list covers both). The native-open methods are denied so
+ *  a non-admin session can never pop a host desktop surface — the remote
+ *  browser file panel never reaches the wire for these anyway (the client
+ *  half intercepts the fetch first); this is defense in depth. */
 const NON_ADMIN_DENY = new Set([
 	"settings.describe",
 	"settings.openDocument",
+	"settings.openSettingsDocument",
 	"settings.update",
 	"settings.replace",
 	"settings.mutate",
@@ -94,9 +101,11 @@ const NON_ADMIN_DENY = new Set([
 	"agentPreset.read",
 	"agentPreset.copy",
 	"agentPreset.openDocument",
+	"settings.openAgentPresetDirectory",
 	"agentPreset.remove",
 	"host.pickDirectory",
 	"host.openPath",
+	"session.openWorkspacePath",
 	"llm.discoverModels"
 ]);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xgone/dsh-remote",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Remote access & authentication for the DeepSeek Harness web UI: login gate, MFA (TOTP), signed session cookies, role-based access, in-browser directory picker, account management settings. Fully localized (zh/en).",
   "type": "module",
   "main": "lib/index.js",
@@ -17,9 +17,9 @@
     "LICENSE"
   ],
   "scripts": {
-    "check": "node --check lib/index.js",
-    "test": "node --check lib/index.js && node --test test/gzip.test.js test/remote-file.test.js test/role-gate.test.js test/files-store.test.js test/browser-auth.test.js",
-    "prepublishOnly": "node --check lib/index.js && node --test test/gzip.test.js test/remote-file.test.js test/role-gate.test.js test/files-store.test.js test/browser-auth.test.js"
+    "check": "node --check lib/index.js && node --check lib/client.js",
+    "test": "node --check lib/index.js && node --check lib/client.js && node --test test/gzip.test.js test/remote-file.test.js test/role-gate.test.js test/files-store.test.js test/browser-auth.test.js test/open-path-shape.test.js",
+    "prepublishOnly": "node --check lib/index.js && node --check lib/client.js && node --test test/gzip.test.js test/remote-file.test.js test/role-gate.test.js test/files-store.test.js test/browser-auth.test.js test/open-path-shape.test.js"
   },
   "license": "MIT",
   "author": "xgone <xl.gone@gmail.com>",

--- a/test/open-path-shape.test.js
+++ b/test/open-path-shape.test.js
@@ -1,0 +1,154 @@
+/**
+ * Unit tests for the remote file panel's wire-shape matcher
+ * (lib/client.js `extractNativeOpenPath`).
+ *
+ * dsh renamed the native-open RPC between generations:
+ *   rc    — POST /api/host.openPath             payload { path }
+ *   alpha — POST /api/session/openWorkspacePath payload { args: { request: { path } } }
+ * The matcher must accept both spellings so one bundle serves both dsh
+ * generations (issue #11: after the dsh upgrade the sidebar never opened
+ * because the patch only matched the rc spelling — and alpha additionally
+ * hides the open affordances unless ctx.remote.$host.isLoopback is true,
+ * which the plugin now flips for remote pages in apply()).
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/** Evaluate the self-contained browser bundle and return its module exports
+ *  plus the page `window` object the bundle closed over (the whole source is
+ *  one `new Function("window", …)` body, so `window` is that lexical). */
+function loadClientBundle() {
+	const here = dirname(fileURLToPath(import.meta.url));
+	const source = readFileSync(join(here, "..", "lib", "client.js"), "utf8");
+	const loaded = [];
+	const stubRequire = (name) => {
+		if (name === "react/jsx-runtime") return { jsx: () => null };
+		if (name === "react-dom/client") return { createRoot: () => ({ render: () => {}, unmount: () => {} }) };
+		if (name === "@deepseek-ai/dsh-client-ui-primitives") throw new Error("primitives are optional");
+		return {}; // react and every other shell module
+	};
+	const pageWindow = { __ModuleLoader__: { load: (definition) => loaded.push(definition) } };
+	new Function("window", source)(pageWindow);
+	assert.equal(loaded.length, 1, "the bundle must register exactly one module");
+	return { exports: loaded[0].factory(stubRequire), pageWindow };
+}
+
+const { exports: bundle, pageWindow } = loadClientBundle();
+const extract = bundle.extractNativeOpenPath;
+
+// ── rc generation: dotted endpoint, free-form payload ──────────────────────────
+
+test("extractNativeOpenPath: rc dotted host.openPath with payload.path", () => {
+	const body = JSON.stringify({
+		type: "client-request", rpcId: "rc-1", method: "host.openPath",
+		payload: { path: "/home/you/report.md" }
+	});
+	assert.deepEqual(extract("/api/host.openPath", body), { path: "/home/you/report.md", rpcId: "rc-1" });
+	assert.deepEqual(extract("http://127.0.0.1:3080/api/host.openPath", body), { path: "/home/you/report.md", rpcId: "rc-1" });
+});
+
+// ── alpha generation: slash endpoint, args keyed by authored parameter name ────
+
+test("extractNativeOpenPath: alpha session/openWorkspacePath with args.request.path", () => {
+	// Captured shape: the gateway wraps method arguments in payload.args,
+	// keyed by the authored parameter name (`request` for openWorkspacePath).
+	const body = JSON.stringify({
+		type: "client-request", rpcId: "al-1", method: "session/openWorkspacePath",
+		payload: { args: { request: { path: "/home/you/report.md" } } }
+	});
+	assert.deepEqual(extract("/api/session/openWorkspacePath", body), { path: "/home/you/report.md", rpcId: "al-1" });
+	assert.deepEqual(extract("https://dsh.example.com/api/session/openWorkspacePath", body), { path: "/home/you/report.md", rpcId: "al-1" });
+});
+
+test("extractNativeOpenPath: alpha args are matched generically, not by fixed key", () => {
+	const body = JSON.stringify({
+		type: "client-request", rpcId: "al-2", method: "session/openWorkspacePath",
+		payload: { args: { dir: { path: "/home/you" } } }
+	});
+	assert.deepEqual(extract("/api/session/openWorkspacePath", body), { path: "/home/you", rpcId: "al-2" });
+});
+
+test("extractNativeOpenPath: a missing rpcId still matches with a null id", () => {
+	const body = JSON.stringify({
+		type: "client-request", method: "session/openWorkspacePath",
+		payload: { args: { request: { path: "/tmp/a.md" } } }
+	});
+	assert.deepEqual(extract("/api/session/openWorkspacePath", body), { path: "/tmp/a.md", rpcId: null });
+});
+
+// ── pass-through: anything that is not a native-open must fall through ─────────
+
+test("extractNativeOpenPath: unrelated endpoints return null", () => {
+	const body = JSON.stringify({
+		type: "client-request", rpcId: "x", method: "settings.describe",
+		payload: { args: { request: { path: "/etc/passwd" } } }
+	});
+	assert.equal(extract("/api/settings.describe", body), null);
+	assert.equal(extract("/api/settings/describe", body), null);
+	assert.equal(extract("/api/session/openWorkspacePathX", null), null);
+});
+
+test("extractNativeOpenPath: unreadable or pathless bodies return null", () => {
+	const url = "/api/session/openWorkspacePath";
+	assert.equal(extract(url, undefined), null);
+	assert.equal(extract(url, null), null);
+	assert.equal(extract(url, "{not json"), null);
+	assert.equal(extract(url, JSON.stringify({ type: "client-request", rpcId: "x", payload: {} })), null);
+	assert.equal(extract(url, JSON.stringify({ type: "client-request", rpcId: "x", payload: { args: { request: { path: 42 } } } })), null);
+	const rcUrl = "/api/host.openPath";
+	assert.equal(extract(rcUrl, JSON.stringify({ type: "client-request", rpcId: "x", payload: { path: { nested: true } } })), null);
+});
+
+// ── bundle surface sanity ──────────────────────────────────────────────────────
+
+test("client bundle keeps the client-plugin contract and version marker", () => {
+	assert.equal(typeof bundle.apply, "function");
+	assert.ok(Array.isArray(bundle.inject), "inject must be exported");
+	assert.ok(bundle.inject.includes("connection"), "inject must include connection for the isLoopback flip");
+	assert.equal(typeof extract, "function");
+	assert.equal(typeof bundle.installRemoteFileOpen, "function");
+});
+
+// ── the installed fetch patch answers native-open calls without the network ────
+
+test("installRemoteFileOpen: intercepted native-open returns a compliant server-response", async () => {
+	const reached = [];
+	const originalFetch = (input) => {
+		reached.push(String(input));
+		return Promise.resolve(new Response("{}", { status: 200 }));
+	};
+	pageWindow.fetch = originalFetch;
+	bundle.installRemoteFileOpen();
+	assert.notEqual(pageWindow.fetch, originalFetch, "install must wrap the current fetch");
+	const patchedFetch = pageWindow.fetch;
+
+	const alphaBody = JSON.stringify({
+		type: "client-request", rpcId: "e2e-alpha", method: "session/openWorkspacePath",
+		payload: { args: { request: { path: "/home/you/a.md" } } }
+	});
+	const response = await patchedFetch("/api/session/openWorkspacePath", { method: "POST", body: alphaBody });
+	assert.equal(response.status, 200);
+	assert.deepEqual(await response.json(), {
+		type: "server-response", rpcId: "e2e-alpha",
+		result: { ok: true, value: { opened: true } }
+	});
+
+	const rcBody = JSON.stringify({
+		type: "client-request", rpcId: "e2e-rc", method: "host.openPath",
+		payload: { path: "/home/you/b.md" }
+	});
+	const rcResponse = await patchedFetch("https://host/api/host.openPath", { method: "POST", body: rcBody });
+	assert.deepEqual(await rcResponse.json(), {
+		type: "server-response", rpcId: "e2e-rc",
+		result: { ok: true, value: { opened: true } }
+	});
+
+	assert.deepEqual(reached, [], "intercepted calls must never reach the real fetch");
+
+	// Anything else passes through untouched.
+	await patchedFetch("/api/settings.describe", { method: "POST", body: "{}" });
+	assert.deepEqual(reached, ["/api/settings.describe"]);
+});

--- a/test/role-gate.test.js
+++ b/test/role-gate.test.js
@@ -64,6 +64,20 @@ test("evaluateRoleGate: dsh alpha slash endpoint names hit the dotted deny lists
 	assert.equal(evaluateRoleGate("/api/workspace/list", "POST", clientRequest("workspace/list"), "guest").allowed, true);
 });
 
+test("evaluateRoleGate: alpha native-open renames are denied for non-admin", () => {
+	// dsh ≥ 0.1.2-alpha removed the rc `host.*` / `agentPreset.openDocument`
+	// surfaces; the same native-open privileges now live under new names and
+	// must stay non-admin-denied (the remote file panel never reaches the
+	// wire for these — the client half intercepts the fetch first — so this
+	// is defense in depth for loopback multi-role deployments).
+	assert.equal(evaluateRoleGate("/api/session/openWorkspacePath", "POST", clientRequest("session/openWorkspacePath"), "user").allowed, false);
+	assert.equal(evaluateRoleGate("/api/settings/openSettingsDocument", "POST", clientRequest("settings/openSettingsDocument"), "user").allowed, false);
+	assert.equal(evaluateRoleGate("/api/settings/openAgentPresetDirectory", "POST", clientRequest("settings/openAgentPresetDirectory"), "user").allowed, false);
+	// The capability probes stay callable: the produced-files chips need
+	// session/canOpenWorkspacePath to render the open affordances at all.
+	assert.equal(evaluateRoleGate("/api/session/canOpenWorkspacePath", "POST", clientRequest("session/canOpenWorkspacePath"), "user").allowed, true);
+});
+
 test("evaluateRoleGate: workspace.list is allowed for every role", () => {
 	for (const role of ["admin", "user", "guest"]) {
 		assert.equal(evaluateRoleGate("/api/workspace.list", "POST", clientRequest("workspace.list"), role).allowed, true, role);


### PR DESCRIPTION
## 问题

新版 dsh(0.1.2-alpha)上,远程模式点击文件路径后侧边栏不再打开,文件在宿主机桌面被静默打开(或报错)。

## 根因(两层)

1. **RPC 端点更换**:原生打开从 `host.openPath`(点号端点,`payload.path`)换成 `session.openWorkspacePath`(斜杠端点 `/api/session/openWorkspacePath`,参数在 `payload.args.request.path`),客户端 fetch 拦截只匹配旧形状。
2. **客户端门闩**:新版 UI 只在 `ctx.remote.$host.isLoopback` 为真时渲染打开入口(`canOpenPath = isLoopback && hostCanOpenPath`),远程浏览器根本不渲染按钮。

## 修复

- 拦截器同时匹配两代端点形状(`args` 按方法参数名泛化查找 `path`),同一 bundle 服务 rc 与 alpha;
- 远程页面把 `ctx.connection.isLoopback` 事实翻转为真(客户端半区的 trustProxy;服务端角色门禁仍是执行点);
- 角色门禁拒绝表补齐 alpha 新名(`session.openWorkspacePath` 等),非 admin 依旧无法触发宿主机桌面打开;
- 测试:e2e fetch 拦截夹具 + 门禁用例,73 项全部通过。

升级插件并重启 `dsh web` 后生效,远程浏览器无需重新登录。